### PR TITLE
Changed reactivate's tests order

### DIFF
--- a/test/liquidate/reactivate.ts
+++ b/test/liquidate/reactivate.ts
@@ -4,6 +4,7 @@ import * as utils from '../helpers/utils';
 import { expect } from 'chai';
 import { trackGas, GasGroup } from '../helpers/gas-usage';
 
+// Deaclare globals
 let ssvNetworkContract: any, minDepositAmount: any, firstPod: any;
 
 describe('Reactivate Tests', () => {


### PR DESCRIPTION
** one test is missing:
it('Reactivate gas limits', async () => {
    await utils.progressBlocks(helpers.CONFIG.minimalBlocksBeforeLiquidation);
    await ssvNetworkContract.liquidate(helpers.DB.owners[4].address, clusterResult1.clusterId);
    await helpers.DB.ssvToken.connect(helpers.DB.owners[4]).approve(ssvNetworkContract.address, minDepositAmount);

    await trackGas(ssvNetworkContract.connect(helpers.DB.owners[4]).reactivatePod(clusterResult1.clusterId, minDepositAmount), [GasGroup.REACTIVATE_POD]);
    
    it got deleted in this PR: https://github.com/bloxapp/ssv-network/pull/131/files#diff-23e00c565a96eb3f3c9a709465b7751163757f813174e912f65557a9d39c6bbd