### PR TITLE
Or liquidate tests

### DIFF
--- a/test/liquidate/reactivate.ts
+++ b/test/liquidate/reactivate.ts
@@ -4,6 +4,7 @@ import * as utils from '../helpers/utils';
 import { expect } from 'chai';
 import { trackGas, GasGroup } from '../helpers/gas-usage';
 
+// Deaclare globals
 let ssvNetworkContract: any, minDepositAmount: any, firstPod: any;
 
 describe('Reactivate Tests', () => {


### PR DESCRIPTION
**Test missing:**
 it('Liquidate a pod gas limits', async () => {
    await utils.progressBlocks(helpers.CONFIG.minimalBlocksBeforeLiquidation);
    await trackGas(ssvNetworkContract.connect(helpers.DB.owners[1]).liquidate(helpers.DB.owners[4].address, clusterResult1.clusterId), [GasGroup.LIQUIDATE_POD]);
  }); 
  
  **Also this** -  it('Liquidate validator with a removed operator in a cluster', async () => {
    await ssvNetworkContract.removeOperator(1);
    await utils.progressBlocks(helpers.CONFIG.minimalBlocksBeforeLiquidation); // TMP IT FAILS WITH PROGRESS BLOCK, CRITICAL ERROR IN INDEX MATH LOGIC
    await trackGas(ssvNetworkContract.liquidate(helpers.DB.owners[4].address, clusterResult1.clusterId), [GasGroup.LIQUIDATE_POD]);
  }); 
  **Changed to this-**   it('Liquidate validator with removed operator in a pod', async () => {
    await ssvNetworkContract.removeOperator(1);
    await utils.progressBlocks(helpers.CONFIG.minimalBlocksBeforeLiquidation); // TMP IT FAILS WITH PROGRESS BLOCK, CRITICAL ERROR IN INDEX MATH LOGIC
    await trackGas(ssvNetworkContract.liquidatePod(
      firstPod.ownerAddress,
      firstPod.operatorIds,
      firstPod.pod
    ), [GasGroup.LIQUIDATE_POD]);
  });
  
  Also there're 4 new test:
  1. Liquidatable with removed operator
  
  2. Liquidate a pod that is not liquidatable reverts "PodDataIsBroken" - pay attention is almost the same name as "Liquidate a pod that is not liquidatable reverts "PodNotLiquidatable""
  
  3. Liquidate second time a pod that is liquidated already reverts "PodIsLiquidated"
  
  4. Is liquidated reverts "PodNotExists