### PR TITLE
Andrew branch - liquidate changes

### DIFF
--- a/test/liquidate/liquidate.ts
+++ b/test/liquidate/liquidate.ts
@@ -4,6 +4,7 @@ import * as utils from '../helpers/utils';
 import { expect } from 'chai';
 import { trackGas, GasGroup } from '../helpers/gas-usage';
 
+// Declare globals
 let ssvNetworkContract: any, minDepositAmount: any, firstPod: any;
 
 describe('Liquidate Tests', () => {
@@ -54,18 +55,7 @@ describe('Liquidate Tests', () => {
     firstPod = register.eventsByName.ValidatorAdded[0].args;
   });
 
-  it('Get if the pod is liquidatable', async () => {
-    await utils.progressBlocks(helpers.CONFIG.minimalBlocksBeforeLiquidation);
-    expect(await ssvNetworkContract.isLiquidatable(firstPod.ownerAddress, firstPod.operatorIds, firstPod.pod)).to.equal(true);
-  });
-
-  it('Liquidatable with removed operator', async () => {
-    await ssvNetworkContract.removeOperator(1);
-    await utils.progressBlocks(helpers.CONFIG.minimalBlocksBeforeLiquidation); // TMP IT FAILS WITH PROGRESS BLOCK, CRITICAL ERROR IN INDEX MATH LOGIC
-    expect(await ssvNetworkContract.isLiquidatable(firstPod.ownerAddress, firstPod.operatorIds, firstPod.pod)).to.equal(true);
-  });
-
-  it('Liquidate emits PodLiquidated event', async () => {
+  it('Liquidate a pod emits "PodLiquidated"', async () => {
     await utils.progressBlocks(helpers.CONFIG.minimalBlocksBeforeLiquidation);
 
     await expect(ssvNetworkContract.liquidatePod(
@@ -73,6 +63,29 @@ describe('Liquidate Tests', () => {
       firstPod.operatorIds,
       firstPod.pod
     )).to.emit(ssvNetworkContract, 'PodLiquidated');
+  });
+
+  it('Get if the pod is liquidatable', async () => {
+    await utils.progressBlocks(helpers.CONFIG.minimalBlocksBeforeLiquidation);
+    expect(await ssvNetworkContract.isLiquidatable(firstPod.ownerAddress, firstPod.operatorIds, firstPod.pod)).to.equal(true);
+  });
+
+  it('Get if the pod is liquidated', async () => {
+    await utils.progressBlocks(helpers.CONFIG.minimalBlocksBeforeLiquidation);
+    const liquidatedPod = await trackGas(ssvNetworkContract.liquidatePod(
+      firstPod.ownerAddress,
+      firstPod.operatorIds,
+      firstPod.pod
+    ), [GasGroup.LIQUIDATE_POD]);
+    const updatedPod = liquidatedPod.eventsByName.PodLiquidated[0].args;
+
+    expect(await ssvNetworkContract.isLiquidated(firstPod.ownerAddress, firstPod.operatorIds, updatedPod.pod)).to.equal(true);
+  });
+
+  it('Liquidatable with removed operator', async () => {
+    await ssvNetworkContract.removeOperator(1);
+    await utils.progressBlocks(helpers.CONFIG.minimalBlocksBeforeLiquidation); // TMP IT FAILS WITH PROGRESS BLOCK, CRITICAL ERROR IN INDEX MATH LOGIC
+    expect(await ssvNetworkContract.isLiquidatable(firstPod.ownerAddress, firstPod.operatorIds, firstPod.pod)).to.equal(true);
   });
 
   it('Liquidate validator with removed operator in a pod', async () => {
@@ -85,7 +98,7 @@ describe('Liquidate Tests', () => {
     ), [GasGroup.LIQUIDATE_POD]);
   });
 
-  it('Liquidate and register validator in disabled pod', async () => {
+  it('Liquidate and register validator to disabled pod', async () => {
     await utils.progressBlocks(helpers.CONFIG.minimalBlocksBeforeLiquidation);
     const liquidatedPod = await trackGas(ssvNetworkContract.liquidatePod(
       firstPod.ownerAddress,
@@ -128,7 +141,7 @@ describe('Liquidate Tests', () => {
     )).to.be.revertedWith('PodDataIsBroken');
   });
 
-  it('Liquidate second time a pod that is liquidated already reverts "PodIsLiquidated"', async () => {
+  it('Liquidate a pod that is already liquidated reverts "PodIsLiquidated"', async () => {
     await utils.progressBlocks(helpers.CONFIG.minimalBlocksBeforeLiquidation);
     const liquidatedPod = await trackGas(ssvNetworkContract.liquidatePod(
       firstPod.ownerAddress,
@@ -144,19 +157,8 @@ describe('Liquidate Tests', () => {
     )).to.be.revertedWith('PodIsLiquidated');
   });
 
-  it('Is liquidated', async () => {
-    await utils.progressBlocks(helpers.CONFIG.minimalBlocksBeforeLiquidation);
-    const liquidatedPod = await trackGas(ssvNetworkContract.liquidatePod(
-      firstPod.ownerAddress,
-      firstPod.operatorIds,
-      firstPod.pod
-    ), [GasGroup.LIQUIDATE_POD]);
-    const updatedPod = liquidatedPod.eventsByName.PodLiquidated[0].args;
 
-    expect(await ssvNetworkContract.isLiquidated(firstPod.ownerAddress, firstPod.operatorIds, updatedPod.pod)).to.equal(true);
-  });
-
-  it('Is liquidated reverts "PodNotExists"', async () => {
+  it('Get if a pod that does not exist is liquidated reverts "PodNotExists"', async () => {
     await utils.progressBlocks(helpers.CONFIG.minimalBlocksBeforeLiquidation);
     const liquidatedPod = await trackGas(ssvNetworkContract.liquidatePod(
       firstPod.ownerAddress,
@@ -167,5 +169,4 @@ describe('Liquidate Tests', () => {
 
     await expect(ssvNetworkContract.isLiquidated(helpers.DB.owners[0].address, firstPod.operatorIds, updatedPod.pod)).to.be.revertedWith('PodNotExists');
   });
-
 });


### PR DESCRIPTION
Test missing:
it('Liquidate a pod gas limits', async () => {
await utils.progressBlocks(helpers.CONFIG.minimalBlocksBeforeLiquidation);
await trackGas(ssvNetworkContract.connect(helpers.DB.owners[1]).liquidate(helpers.DB.owners[4].address, clusterResult1.clusterId), [GasGroup.LIQUIDATE_POD]);
}); 

Also this - it('Liquidate validator with a removed operator in a cluster', async () => {
await ssvNetworkContract.removeOperator(1);
await utils.progressBlocks(helpers.CONFIG.minimalBlocksBeforeLiquidation); // TMP IT FAILS WITH PROGRESS BLOCK, CRITICAL ERROR IN INDEX MATH LOGIC
await trackGas(ssvNetworkContract.liquidate(helpers.DB.owners[4].address, clusterResult1.clusterId), [GasGroup.LIQUIDATE_POD]);
});
Changed to this- it('Liquidate validator with removed operator in a pod', async () => {
await ssvNetworkContract.removeOperator(1);
await utils.progressBlocks(helpers.CONFIG.minimalBlocksBeforeLiquidation); // TMP IT FAILS WITH PROGRESS BLOCK, CRITICAL ERROR IN INDEX MATH LOGIC
await trackGas(ssvNetworkContract.liquidatePod(
firstPod.ownerAddress,
firstPod.operatorIds,
firstPod.pod
), [GasGroup.LIQUIDATE_POD]);
});

Also there're 4 new test:

Liquidatable with removed operator

Liquidate a pod that is not liquidatable reverts "PodDataIsBroken" - pay attention is almost the same name as "Liquidate a pod that is not liquidatable reverts "PodNotLiquidatable""

Liquidate second time a pod that is liquidated already reverts "PodIsLiquidated"

Is liquidated reverts "PodNotExists