### PR TITLE
list of gas optz changes IO1-1433

### DIFF
--- a/contracts/SSVNetwork.sol
+++ b/contracts/SSVNetwork.sol
@@ -235,7 +235,7 @@ contract SSVNetwork is OwnableUpgradeable, ISSVNetwork {
     /********************************/
     function registerValidator(
         bytes calldata publicKey,
-        uint64[] calldata operatorIds,
+        uint64[] memory operatorIds,
         bytes calldata shares,
         uint256 amount,
         Pod memory pod
@@ -315,7 +315,7 @@ contract SSVNetwork is OwnableUpgradeable, ISSVNetwork {
 
     function removeValidator(
         bytes calldata publicKey,
-        uint64[] calldata operatorIds,
+        uint64[] memory operatorIds,
         Pod memory pod
     ) external override {
         uint operatorsLength = operatorIds.length;
@@ -368,7 +368,7 @@ contract SSVNetwork is OwnableUpgradeable, ISSVNetwork {
 
     function liquidatePod(
         address owner,
-        uint64[] calldata operatorIds,
+        uint64[] memory operatorIds,
         Pod memory pod
     ) external override {
         _validatePodIsNotLiquidated(pod);
@@ -420,7 +420,7 @@ contract SSVNetwork is OwnableUpgradeable, ISSVNetwork {
     }
 
     function reactivatePod(
-        uint64[] calldata operatorIds,
+        uint64[] memory operatorIds,
         uint256 amount,
         Pod memory pod
     ) external override {
@@ -561,7 +561,7 @@ contract SSVNetwork is OwnableUpgradeable, ISSVNetwork {
     }
 
     function withdrawPodBalance(
-        uint64[] calldata operatorIds,
+        uint64[] memory operatorIds,
         uint256 amount,
         Pod memory pod
     ) external override {
@@ -860,7 +860,7 @@ contract SSVNetwork is OwnableUpgradeable, ISSVNetwork {
     /* Pod Private Functions */
     /*************************/
 
-    function _validateHashedPod(address owner, uint64[] calldata operatorIds, Pod memory pod) private view returns (bytes32) {
+    function _validateHashedPod(address owner, uint64[] memory operatorIds, Pod memory pod) private view returns (bytes32) {
         bytes32 hashedPod = keccak256(abi.encodePacked(owner, operatorIds));
         {
             bytes32 hashedPodData = keccak256(abi.encodePacked(pod.validatorCount, pod.networkFee, pod.networkFeeIndex, pod.index, pod.balance, pod.disabled ));
@@ -900,7 +900,7 @@ contract SSVNetwork is OwnableUpgradeable, ISSVNetwork {
     /* Balance Private Functions */
     /*****************************/
 
-    function _deposit(address owner, uint64[] calldata operatorIds, uint64 amount) private {
+    function _deposit(address owner, uint64[] memory operatorIds, uint64 amount) private {
         _token.transferFrom(msg.sender, address(this), amount.expand());
         emit FundsDeposit(amount.expand(), operatorIds, owner);
     }


### PR DESCRIPTION
Link to document:
[https://docs.google.com/document/d/1UONeUat6DFKZI-E9aiG0eKkhShamU2q3g0KAsmC6BKI](https://docs.google.com/document/d/1UONeUat6DFKZI-E9aiG0eKkhShamU2q3g0KAsmC6BKI)

- [x] for loops
- [x] Return calculated values from private functions to not recalculate / access them again and to avoid repetitive checks
- [x] Nested if
- [x] Use calldata in function parameters when possible (see comments in doc, although it can represent some savings in specific functions, overall it doesn't represent a gain)
- [-] No need to initialize variables with default values
- [x] Follow check-effects-interaction pattern
- [x] No repeated computations
- [x] Check proper copy of storage structs to memory

| function  | contract-v3  | v3-gas-optimizations | savings |
|---|---|---|---|
| liquidatePod  | 131499  |  129601 | 1898  |
| reactivatePod  |  125151 |  124879 | 272 |  
| registerValidator  |  214782 |  213831 | 951 |   
| removeValidator  | 96911 |  96440 | 471 | 
| withdrawPodBalance |  91924|  89996 | 1928 | 
