### PR TITLE
Compact struct to save one slot

### DIFF
--- a/contracts/SSVNetwork.sol
+++ b/contracts/SSVNetwork.sol
@@ -16,8 +16,8 @@ contract SSVNetwork is OwnableUpgradeable, ISSVNetwork, VersionedContract {
         uint256 blockNumber;
         uint64 earnings;
         uint64 index;
-        uint256 indexBlockNumber;
         uint32 activeValidatorCount;
+        uint256 indexBlockNumber;
     }
 
     struct OwnerData {


### PR DESCRIPTION
Current struct:
```
uint256 blockNumber; // slot 0
uint64 earnings; // slot 1
uint64 index; // slot 1
uint256 indexBlockNumber; // slot 2
uint32 activeValidatorCount; // slot 3
```

Suggestion:
```
uint256 blockNumber; // slot 0
uint256 indexBlockNumber; // slot 1
uint64 earnings; // slot 2
uint64 index; // slot 2
uint32 activeValidatorCount; // slot 2
```
