### PR TITLE
Publish NPM package with contracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,10 @@
 {
-  "name": "ssv-network",
+  "name": "@bloxapp/ssv-network",
+  "version": "0.2.0",
+  "files": [
+    "/contracts/**/*.sol",
+    "!/contracts/mocks/**/*"
+  ],
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.5",
     "@nomiclabs/hardhat-etherscan": "^3.0.3",
@@ -30,5 +35,12 @@
     "ts-node": "^10.7.0",
     "typechain": "^3.0.0",
     "typescript": "^4.6.3"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bloxapp/ssv-network.git"
   }
 }


### PR DESCRIPTION
As StakeStar we are building Liquid Staking pool based on SSV Network and obviously we are using your contracts under the hood. 

Your contracts aren't published anywhere via NPM packages, so we have to manually copy-paste them into our repo.

You are going to publish fresh contracts(v3) soon and we will have to copy-paste them again.

This pull-request adds required configuration to package.json to allow publishing to npm.pkg.github.com and easier integration for protocols. After merging, please consider setting correct version and publishing a package for every release.