### PR TITLE
Fix cluster's withdraw action

### DIFF
--- a/contracts/SSVNetwork.sol
+++ b/contracts/SSVNetwork.sol
@@ -551,8 +551,11 @@ contract SSVNetwork is UUPSUpgradeable, Ownable2StepUpgradeable, ISSVNetwork {
 
         cluster.updateClusterData(clusterIndex, NetworkLib.currentNetworkFeeIndex(network));
 
+        if (cluster.balance < amount) revert InsufficientBalance();
+
+        cluster.balance -= amount;
+
         if (
-            cluster.balance < amount ||
             cluster.isLiquidatable(
                 burnRate,
                 network.networkFee,
@@ -562,8 +565,6 @@ contract SSVNetwork is UUPSUpgradeable, Ownable2StepUpgradeable, ISSVNetwork {
         ) {
             revert InsufficientBalance();
         }
-
-        cluster.balance -= amount;
 
         clusters[hashedCluster] = keccak256(
             abi.encodePacked(

--- a/test/account/withdraw.ts
+++ b/test/account/withdraw.ts
@@ -11,7 +11,7 @@ describe('Withdraw Tests', () => {
   beforeEach(async () => {
     // Initialize contract
     ssvNetworkContract = (await helpers.initializeContract()).contract;
-
+    
     // Register operators
     await helpers.registerOperators(0, 12, helpers.CONFIG.minimalOperatorFee);
 
@@ -70,12 +70,17 @@ describe('Withdraw Tests', () => {
     await expect(ssvNetworkContract.connect(helpers.DB.owners[4]).withdraw(cluster1.args.operatorIds, minDepositAmount, cluster1.args.cluster)).to.be.revertedWithCustomError(ssvNetworkContract,'InsufficientBalance');
   });
 
-  it('Withdraw from a liquidatable cluster reverts "InsufficientBalance"', async () => {
-    await utils.progressBlocks(helpers.CONFIG.minimalBlocksBeforeLiquidation);
-    await expect(ssvNetworkContract.connect(helpers.DB.owners[4]).withdraw(cluster1.args.operatorIds, helpers.CONFIG.minimalOperatorFee, cluster1.args.cluster)).to.be.revertedWithCustomError(ssvNetworkContract,'InsufficientBalance');
+  it('Withdraw from a liquidatable cluster reverts "InsufficientBalance" (liquidation threshold)', async () => {
+    await utils.progressBlocks(20);
+    await expect(ssvNetworkContract.connect(helpers.DB.owners[4]).withdraw(cluster1.args.operatorIds, 4000000000, cluster1.args.cluster)).to.be.revertedWithCustomError(ssvNetworkContract,'InsufficientBalance');
   });
 
-  it('Withdraw from a liquidatable cluster after liquidatrion period reverts "InsufficientBalance"', async () => {
+  it('Withdraw from a liquidatable cluster reverts "InsufficientBalance" (liquidation collateral)', async () => {
+    await utils.progressBlocks(helpers.CONFIG.minimalBlocksBeforeLiquidation - 10);
+    await expect(ssvNetworkContract.connect(helpers.DB.owners[4]).withdraw(cluster1.args.operatorIds, 7500000000, cluster1.args.cluster)).to.be.revertedWithCustomError(ssvNetworkContract,'InsufficientBalance');
+  });
+
+  it('Withdraw from a liquidatable cluster after liquidation period reverts "InsufficientBalance"', async () => {
     await utils.progressBlocks(helpers.CONFIG.minimalBlocksBeforeLiquidation + 10);
     await expect(ssvNetworkContract.connect(helpers.DB.owners[4]).withdraw(cluster1.args.operatorIds, helpers.CONFIG.minimalOperatorFee, cluster1.args.cluster)).to.be.revertedWithCustomError(ssvNetworkContract,'InsufficientBalance');
   });

--- a/test/helpers/contract-helpers.ts
+++ b/test/helpers/contract-helpers.ts
@@ -69,7 +69,7 @@ export const initializeContract = async () => {
     executeOperatorFeePeriod: 86400, // DAY
     minimalOperatorFee: 100000000,
     minimalBlocksBeforeLiquidation: 100800,
-    minimumLiquidationCollateral: 60000000
+    minimumLiquidationCollateral: 200000000
   };
 
   DB = {


### PR DESCRIPTION
The amount that can be withdrawn from a cluster is in between its current balance and the greater of the liquidation threshold amount or the liquidation collateral.