### PR TITLE
Views contract audit recommendations 

### DIFF
--- a/contracts/SSVNetworkViews.sol
+++ b/contracts/SSVNetworkViews.sol
@@ -20,7 +20,7 @@ contract SSVNetworkViews is UUPSUpgradeable, Ownable2StepUpgradeable, ISSVViews 
 
     // @dev reserve storage space for future new state variables in base contract
     // slither-disable-next-line shadowing-state
-    uint256[50] private__gap;
+    uint256[50] private __gap;
 
     function _authorizeUpgrade(address) internal override onlyOwner {}
 
@@ -39,8 +39,8 @@ contract SSVNetworkViews is UUPSUpgradeable, Ownable2StepUpgradeable, ISSVViews 
     /* Validator External View Functions */
     /*************************************/
 
-    function getValidator(address owner, bytes calldata publicKey) external view override returns (bool active) {
-        return ssvNetwork.getValidator(owner, publicKey);
+    function getValidator(address clusterOwner, bytes calldata publicKey) external view override returns (bool active) {
+        return ssvNetwork.getValidator(clusterOwner, publicKey);
     }
 
     /************************************/
@@ -51,7 +51,7 @@ contract SSVNetworkViews is UUPSUpgradeable, Ownable2StepUpgradeable, ISSVViews 
         return ssvNetwork.getOperatorFee(operatorId);
     }
 
-    function getOperatorDeclaredFee(uint64 operatorId) external view override returns (uint256, uint64, uint64) {
+    function getOperatorDeclaredFee(uint64 operatorId) external view override returns (bool, uint256, uint64, uint64) {
         return ssvNetwork.getOperatorDeclaredFee(operatorId);
     }
 
@@ -64,27 +64,27 @@ contract SSVNetworkViews is UUPSUpgradeable, Ownable2StepUpgradeable, ISSVViews 
     /***********************************/
 
     function isLiquidatable(
-        address owner,
+        address clusterOwner,
         uint64[] calldata operatorIds,
         Cluster memory cluster
     ) external view override returns (bool) {
-        return ssvNetwork.isLiquidatable(owner, operatorIds, cluster);
+        return ssvNetwork.isLiquidatable(clusterOwner, operatorIds, cluster);
     }
 
     function isLiquidated(
-        address owner,
+        address clusterOwner,
         uint64[] calldata operatorIds,
         Cluster memory cluster
     ) external view override returns (bool) {
-        return ssvNetwork.isLiquidated(owner, operatorIds, cluster);
+        return ssvNetwork.isLiquidated(clusterOwner, operatorIds, cluster);
     }
 
     function getBurnRate(
-        address owner,
+        address clusterOwner,
         uint64[] calldata operatorIds,
         Cluster memory cluster
     ) external view returns (uint256) {
-        return ssvNetwork.getBurnRate(owner, operatorIds, cluster);
+        return ssvNetwork.getBurnRate(clusterOwner, operatorIds, cluster);
     }
 
     /***********************************/
@@ -96,11 +96,11 @@ contract SSVNetworkViews is UUPSUpgradeable, Ownable2StepUpgradeable, ISSVViews 
     }
 
     function getBalance(
-        address owner,
+        address clusterOwner,
         uint64[] calldata operatorIds,
         Cluster memory cluster
     ) external view override returns (uint256) {
-        return ssvNetwork.getBalance(owner, operatorIds, cluster);
+        return ssvNetwork.getBalance(clusterOwner, operatorIds, cluster);
     }
 
     /*******************************/

--- a/contracts/interfaces/ISSVViews.sol
+++ b/contracts/interfaces/ISSVViews.sol
@@ -7,20 +7,21 @@ interface ISSVViews is ISSVNetworkCore {
     /// @notice Gets the validator status
     /// @param owner The address of the validator's owner
     /// @param publicKey The public key of the validator
-    /// @return A boolean indicating if the validator is active
-    function getValidator(address owner, bytes calldata publicKey) external view returns (bool);
+    /// @return active A boolean indicating if the validator is active. If it does not exist, returns false.
+    function getValidator(address owner, bytes calldata publicKey) external view returns (bool active);
 
     /// @notice Gets the operator fee
     /// @param operatorId The ID of the operator
-    /// @return The fee associated with the operator (SSV)
-    function getOperatorFee(uint64 operatorId) external view returns (uint256);
-
+    /// @return fee The fee associated with the operator (SSV). If the operator does not exist, the returned value is 0.
+    function getOperatorFee(uint64 operatorId) external view returns (uint256 fee);
+    
     /// @notice Gets the declared operator fee
     /// @param operatorId The ID of the operator
+    /// @return isFeeDeclared A boolean indicating if the fee is declared
     /// @return fee The declared operator fee (SSV)
     /// @return approvalBeginTime The time when the fee approval process begins
     /// @return approvalEndTime The time when the fee approval process ends
-    function getOperatorDeclaredFee(uint64 operatorId) external view returns (uint256 fee, uint64 approvalBeginTime, uint64 approvalEndTime);
+    function getOperatorDeclaredFee(uint64 operatorId) external view returns (bool isFeeDeclared, uint256 fee, uint64 approvalBeginTime, uint64 approvalEndTime);
 
     /// @notice Gets operator details by ID
     /// @param operatorId The ID of the operator
@@ -52,8 +53,8 @@ interface ISSVViews is ISSVNetworkCore {
 
     /// @notice Gets operator earnings
     /// @param operatorId The ID of the operator
-    /// @return The earnings associated with the operator (SSV)
-    function getOperatorEarnings(uint64 operatorId) external view returns (uint256);
+    /// @return earnings The earnings associated with the operator (SSV)
+    function getOperatorEarnings(uint64 operatorId) external view returns (uint256 earnings);
 
     /// @notice Gets the balance of the cluster
     /// @param owner The owner address of the cluster

--- a/contracts/modules/SSVViews.sol
+++ b/contracts/modules/SSVViews.sol
@@ -21,10 +21,10 @@ contract SSVViews is ISSVViews {
     /* Validator External View Functions */
     /*************************************/
 
-    function getValidator(address owner, bytes calldata publicKey) external view override returns (bool active) {
-        bytes32 validatorData = SSVStorage.load().validatorPKs[keccak256(abi.encodePacked(publicKey, owner))];
+    function getValidator(address clusterOwner, bytes calldata publicKey) external view override returns (bool active) {
+        bytes32 validatorData = SSVStorage.load().validatorPKs[keccak256(abi.encodePacked(publicKey, clusterOwner))];
 
-        if (validatorData == bytes32(0)) revert ValidatorDoesNotExist();
+        if (validatorData == bytes32(0)) return false;
         bytes32 activeFlag = validatorData & bytes32(uint256(1)); // Retrieve LSB of stored value
 
         return activeFlag == bytes32(uint256(1));
@@ -36,20 +36,14 @@ contract SSVViews is ISSVViews {
     /************************************/
 
     function getOperatorFee(uint64 operatorId) external view override returns (uint256 fee) {
-        Operator memory operator = SSVStorage.load().operators[operatorId];
-        if (operator.snapshot.block == 0) revert OperatorDoesNotExist();
-
-        fee = operator.fee.expand();
+        return SSVStorage.load().operators[operatorId].fee.expand();
     }
 
-    function getOperatorDeclaredFee(uint64 operatorId) external view override returns (uint256, uint64, uint64) {
+    function getOperatorDeclaredFee(uint64 operatorId) external view override returns (bool, uint256, uint64, uint64) {
         OperatorFeeChangeRequest memory opFeeChangeRequest = SSVStorage.load().operatorFeeChangeRequests[operatorId];
 
-        if (opFeeChangeRequest.fee == 0) {
-            revert NoFeeDeclared();
-        }
-
         return (
+            opFeeChangeRequest.approvalBeginTime != 0,
             opFeeChangeRequest.fee.expand(),
             opFeeChangeRequest.approvalBeginTime,
             opFeeChangeRequest.approvalEndTime
@@ -70,11 +64,11 @@ contract SSVViews is ISSVViews {
     /***********************************/
 
     function isLiquidatable(
-        address owner,
+        address clusterOwner,
         uint64[] calldata operatorIds,
         Cluster memory cluster
     ) external view override returns (bool) {
-        cluster.validateHashedCluster(owner, operatorIds, SSVStorage.load());
+        cluster.validateHashedCluster(clusterOwner, operatorIds, SSVStorage.load());
 
         if (!cluster.active) {
             return false;
@@ -82,8 +76,8 @@ contract SSVViews is ISSVViews {
 
         uint64 clusterIndex;
         uint64 burnRate;
-        uint operatorsLength = operatorIds.length;
-        for (uint i; i < operatorsLength; ++i) {
+        uint256 operatorsLength = operatorIds.length;
+        for (uint256 i; i < operatorsLength; ++i) {
             Operator memory operator = SSVStorage.load().operators[operatorIds[i]];
             clusterIndex += operator.snapshot.index + (uint64(block.number) - operator.snapshot.block) * operator.fee;
             burnRate += operator.fee;
@@ -102,24 +96,24 @@ contract SSVViews is ISSVViews {
     }
 
     function isLiquidated(
-        address owner,
+        address clusterOwner,
         uint64[] calldata operatorIds,
         Cluster memory cluster
     ) external view override returns (bool) {
-        cluster.validateHashedCluster(owner, operatorIds, SSVStorage.load());
+        cluster.validateHashedCluster(clusterOwner, operatorIds, SSVStorage.load());
         return !cluster.active;
     }
 
     function getBurnRate(
-        address owner,
+        address clusterOwner,
         uint64[] calldata operatorIds,
         Cluster memory cluster
     ) external view returns (uint256) {
-        cluster.validateHashedCluster(owner, operatorIds, SSVStorage.load());
+        cluster.validateHashedCluster(clusterOwner, operatorIds, SSVStorage.load());
 
         uint64 aggregateFee;
-        uint operatorsLength = operatorIds.length;
-        for (uint i; i < operatorsLength; ++i) {
+        uint256 operatorsLength = operatorIds.length;
+        for (uint256 i; i < operatorsLength; ++i) {
             Operator memory operator = SSVStorage.load().operators[operatorIds[i]];
             if (operator.owner != address(0)) {
                 aggregateFee += operator.fee;
@@ -142,17 +136,17 @@ contract SSVViews is ISSVViews {
     }
 
     function getBalance(
-        address owner,
+        address clusterOwner,
         uint64[] calldata operatorIds,
         Cluster memory cluster
     ) external view override returns (uint256) {
-        cluster.validateHashedCluster(owner, operatorIds, SSVStorage.load());
+        cluster.validateHashedCluster(clusterOwner, operatorIds, SSVStorage.load());
         cluster.validateClusterIsNotLiquidated();
 
         uint64 clusterIndex;
         {
-            uint operatorsLength = operatorIds.length;
-            for (uint i; i < operatorsLength; ++i) {
+            uint256 operatorsLength = operatorIds.length;
+            for (uint256 i; i < operatorsLength; ++i) {
                 Operator memory operator = SSVStorage.load().operators[operatorIds[i]];
                 clusterIndex +=
                     operator.snapshot.index +

--- a/contracts/test/SSVViewsT.sol
+++ b/contracts/test/SSVViewsT.sol
@@ -39,16 +39,11 @@ contract SSVViewsT is ISSVViews {
         fee = operator.fee.expand();
     }
 
-    function getOperatorDeclaredFee(uint64 operatorId) external view override returns (uint256, uint64, uint64) {
-        OperatorFeeChangeRequest memory opFeeChangeRequest = SSVStorageUpgrade.load().operatorFeeChangeRequests[
-            operatorId
-        ];
-
-        if (opFeeChangeRequest.fee == 0) {
-            revert NoFeeDeclared();
-        }
+    function getOperatorDeclaredFee(uint64 operatorId) external view override returns (bool feeDeclared, uint256, uint64, uint64) {
+        OperatorFeeChangeRequest memory opFeeChangeRequest = SSVStorage.load().operatorFeeChangeRequests[operatorId];
 
         return (
+            opFeeChangeRequest.approvalBeginTime != 0,
             opFeeChangeRequest.fee.expand(),
             opFeeChangeRequest.approvalBeginTime,
             opFeeChangeRequest.approvalEndTime
@@ -81,8 +76,8 @@ contract SSVViewsT is ISSVViews {
 
         uint64 clusterIndex;
         uint64 burnRate;
-        uint operatorsLength = operatorIds.length;
-        for (uint i; i < operatorsLength; ++i) {
+        uint256 operatorsLength = operatorIds.length;
+        for (uint256 i; i < operatorsLength; ++i) {
             Operator memory operator = SSVStorage.load().operators[operatorIds[i]];
             clusterIndex += operator.snapshot.index + (uint64(block.number) - operator.snapshot.block) * operator.fee;
             burnRate += operator.fee;
@@ -117,8 +112,8 @@ contract SSVViewsT is ISSVViews {
         cluster.validateHashedCluster(owner, operatorIds, SSVStorage.load());
 
         uint64 aggregateFee;
-        uint operatorsLength = operatorIds.length;
-        for (uint i; i < operatorsLength; ++i) {
+        uint256 operatorsLength = operatorIds.length;
+        for (uint256 i; i < operatorsLength; ++i) {
             Operator memory operator = SSVStorageUpgrade.load().operators[operatorIds[i]];
             if (operator.owner != address(0)) {
                 aggregateFee += operator.fee;
@@ -150,8 +145,8 @@ contract SSVViewsT is ISSVViews {
 
         uint64 clusterIndex;
         {
-            uint operatorsLength = operatorIds.length;
-            for (uint i; i < operatorsLength; ++i) {
+            uint256 operatorsLength = operatorIds.length;
+            for (uint256 i; i < operatorsLength; ++i) {
                 Operator memory operator = SSVStorage.load().operators[operatorIds[i]];
                 clusterIndex +=
                     operator.snapshot.index +

--- a/test/operators/update-fee.ts
+++ b/test/operators/update-fee.ts
@@ -24,7 +24,7 @@ describe('Operator Fee Tests', () => {
 
   it('Declare fee gas limits"', async () => {
     await trackGas(ssvNetworkContract.connect(helpers.DB.owners[2]).declareOperatorFee(1, initialFee + initialFee / 10
-    ),[GasGroup.DECLARE_OPERATOR_FEE]);
+    ), [GasGroup.DECLARE_OPERATOR_FEE]);
   });
 
   it('Declare fee with zero value emits "OperatorFeeDeclared"', async () => {
@@ -68,9 +68,8 @@ describe('Operator Fee Tests', () => {
     expect(await ssvViews.getOperatorFee(1)).to.equal(initialFee);
   });
 
-  it('Get fee from operator that does not exist reverts "OperatorDoesNotExist"', async () => {
-    await expect(ssvViews.getOperatorFee(12
-    )).to.be.revertedWithCustomError(ssvNetworkContract, 'OperatorDoesNotExist');
+  it('Get fee from operator that does not exist returns 0', async () => {
+    expect(await ssvViews.getOperatorFee(12)).to.equal(0);
   });
 
   it('Declare fee of operator I do not own reverts "CallerNotOwner"', async () => {
@@ -170,8 +169,8 @@ describe('Operator Fee Tests', () => {
 
     expect(await ssvNetworkContract.connect(helpers.DB.owners[2]).reduceOperatorFee(1, initialFee / 2)).to.emit(ssvNetworkContract, 'OperatorFeeExecuted');
     expect(await ssvViews.getOperatorFee(1)).to.equal(initialFee / 2);
-    await expect(ssvViews.getOperatorDeclaredFee(1
-    )).to.be.revertedWithCustomError(ssvNetworkContract, 'NoFeeDeclared');
+    const [isFeeDeclared] = await ssvViews.getOperatorDeclaredFee(1);
+    expect(isFeeDeclared).to.equal(false);
   });
 
   //Dao
@@ -192,7 +191,7 @@ describe('Operator Fee Tests', () => {
 
   it('DAO update the declare fee period gas limits"', async () => {
     await trackGas(ssvNetworkContract.updateDeclareOperatorFeePeriod(1200
-      ), [GasGroup.OPERATOR_DECLARE_FEE_LIMIT]);
+    ), [GasGroup.OPERATOR_DECLARE_FEE_LIMIT]);
   });
 
   it('DAO update the execute fee period emits "ExecuteOperatorFeePeriodUpdated"', async () => {
@@ -202,7 +201,7 @@ describe('Operator Fee Tests', () => {
 
   it('DAO update the execute fee period gas limits', async () => {
     await trackGas(ssvNetworkContract.updateExecuteOperatorFeePeriod(1200
-      ), [GasGroup.OPERATOR_EXECUTE_FEE_LIMIT]);
+    ), [GasGroup.OPERATOR_EXECUTE_FEE_LIMIT]);
   });
 
   it('DAO get fee increase limit', async () => {
@@ -212,7 +211,7 @@ describe('Operator Fee Tests', () => {
   it('DAO get declared fee', async () => {
     const newFee = initialFee + initialFee / 10;
     await trackGas(ssvNetworkContract.connect(helpers.DB.owners[2]).declareOperatorFee(1, newFee), [GasGroup.REGISTER_OPERATOR]);
-    const [feeDeclaredInContract] = await ssvViews.getOperatorDeclaredFee(1);
+    const [_, feeDeclaredInContract] = await ssvViews.getOperatorDeclaredFee(1);
     expect(feeDeclaredInContract).to.equal(newFee);
   });
 
@@ -237,7 +236,7 @@ describe('Operator Fee Tests', () => {
 
   it('DAO declared fee without a pending request reverts "NoFeeDeclared"', async () => {
     await trackGas(ssvNetworkContract.connect(helpers.DB.owners[2]).declareOperatorFee(1, initialFee + initialFee / 10), [GasGroup.REGISTER_OPERATOR]);
-    await expect(ssvViews.getOperatorDeclaredFee(2
-    )).to.be.revertedWithCustomError(ssvNetworkContract, 'NoFeeDeclared');
+    const [isFeeDeclared] = await ssvViews.getOperatorDeclaredFee(2);
+    expect(isFeeDeclared).to.equal(false);
   });
 });

--- a/test/validators/register.ts
+++ b/test/validators/register.ts
@@ -843,6 +843,6 @@ describe('Register Validator Tests', () => {
   });
 
   it('Retrieve a non-existing validator', async () => {
-    await expect(ssvViews.getValidator(helpers.DB.owners[2].address, helpers.DataGenerator.publicKey(90))).to.be.revertedWithCustomError(ssvNetworkContract, 'ValidatorDoesNotExist');
+    expect(await ssvViews.getValidator(helpers.DB.owners[2].address, helpers.DataGenerator.publicKey(90))).to.equal(false);
   });
 });


### PR DESCRIPTION
- [x] The local variable owner shadows the function OwnableUpgradeable.owner() ; consider renaming the variable to avoid shadow conflicts in the following functions:
- SSVNetworkViews.getValidator()
- SSVNetworkViews.isLiquidatable() 
- SSVNetworkViews.isLiquidated()
- SSVNetworkViews.getBurnRate()
- SSVNetworkViews.getBalance()
- [x] In SSVNetworkViews, the state variable __gap is missing a space between private and __gap . upgrade safe
- [x] It is recommended to use explicit type widths over implicit ones.x
- [x] SSV21 Fee Change Request Viewer Function Fails with Zero Fee Request = remove reverts from Views module

**ABI changes**
function getOperatorDeclaredFee -> getOperatorDeclaredFee(uint64 operatorId) external view returns (**bool isFeeDeclared**, uint256 fee, uint64 approvalBeginTime, uint64 approvalEndTime)

**Upgrade plan**

After updating SSVClusters, SSVDAO, SSVOperators and upgrading SSVNetwork, update SSVViews module and upgrade SSVNetworkViews contract