### PR TITLE
DAO audit recommendations

### DIFF
--- a/contracts/modules/SSVDAO.sol
+++ b/contracts/modules/SSVDAO.sol
@@ -3,24 +3,21 @@ pragma solidity 0.8.18;
 
 import "../interfaces/ISSVDAO.sol";
 import "../libraries/Types.sol";
-import "../libraries/OperatorLib.sol";
 import "../libraries/ProtocolLib.sol";
-import "../libraries/CoreLib.sol";
-import "../libraries/SSVStorage.sol";
 
 contract SSVDAO is ISSVDAO {
     using Types64 for uint64;
     using Types256 for uint256;
 
     using ProtocolLib for StorageProtocol;
-    
+
     uint64 private constant MINIMAL_LIQUIDATION_THRESHOLD = 100_800;
 
     function updateNetworkFee(uint256 fee) external override {
-        uint64 previousFee = SSVStorageProtocol.load().networkFee;
+        StorageProtocol storage sp = SSVStorageProtocol.load();
+        uint64 previousFee = sp.networkFee;
 
-        SSVStorageProtocol.load().updateNetworkFee(fee);
-
+        sp.updateNetworkFee(fee);
         emit NetworkFeeUpdated(previousFee, fee);
     }
 

--- a/contracts/modules/SSVDAO.sol
+++ b/contracts/modules/SSVDAO.sol
@@ -18,7 +18,7 @@ contract SSVDAO is ISSVDAO {
         uint64 previousFee = sp.networkFee;
 
         sp.updateNetworkFee(fee);
-        emit NetworkFeeUpdated(previousFee, fee);
+        emit NetworkFeeUpdated(previousFee.expand(), fee);
     }
 
     function withdrawNetworkEarnings(uint256 amount) external override {

--- a/contracts/test/libraries/CoreLibT.sol
+++ b/contracts/test/libraries/CoreLibT.sol
@@ -6,7 +6,7 @@ import "../../libraries/SSVStorage.sol";
 library CoreLibT {
 
     function getVersion() internal pure returns (string memory) {
-        return "v1.0.0";
+        return "v1.0.0.rc2";
     }
 
     function transfer(address to, uint256 amount) internal {

--- a/test/dao/network-fee-change.ts
+++ b/test/dao/network-fee-change.ts
@@ -22,6 +22,14 @@ describe('Network Fee Tests', () => {
     )).to.emit(ssvNetworkContract, 'NetworkFeeUpdated').withArgs(0, networkFee);
   });
 
+  it('Change network fee when it was set emits "NetworkFeeUpdated"', async () => {
+    const initialNetworkFee = helpers.CONFIG.minimalOperatorFee;
+    await ssvNetworkContract.updateNetworkFee(initialNetworkFee);
+
+    await expect(ssvNetworkContract.updateNetworkFee(networkFee
+    )).to.emit(ssvNetworkContract, 'NetworkFeeUpdated').withArgs(initialNetworkFee, networkFee);
+  });
+
   it('Change network fee gas limit', async () => {
     await trackGas(ssvNetworkContract.updateNetworkFee(networkFee), [GasGroup.NETWORK_FEE_CHANGE]);
   });

--- a/test/deployment/version.ts
+++ b/test/deployment/version.ts
@@ -20,7 +20,7 @@ describe('Version upgrade tests', () => {
 
         await ssvNetworkContract.updateModule(helpers.SSV_MODULES.SSV_VIEWS, viewsContract.address)
 
-        expect(await ssvNetworkViews.getVersion()).to.equal("v1.0.0");
+        expect(await ssvNetworkViews.getVersion()).to.equal("v1.0.0.rc2");
     });
 
 });

--- a/test/helpers/contract-helpers.ts
+++ b/test/helpers/contract-helpers.ts
@@ -65,7 +65,7 @@ export const DataGenerator = {
 
 export const initializeContract = async () => {
   CONFIG = {
-    initialVersion: "v1.0.0",
+    initialVersion: "v1.0.0.rc2",
     operatorMaxFeeIncrease: 1000,
     declareOperatorFeePeriod: 3600, // HOUR
     executeOperatorFeePeriod: 86400, // DAY


### PR DESCRIPTION
- [x] When using the Diamond Pattern, the gas consumption can be minimized by load storage pointers only once per function execution. The following functions access the same storage pointer more than once during a single function execution: SSVDAO.updateNetworkFee()

- [x] ProtocolLib.sol#L42 � The check > type(uint32).max is unnecessary -> Keep it because of the explicit revert we use VS default solidity one
- [x] SSV11 Inconsistent Use of shrink() and expand() 

**Upgrade plan**

Update SSVClusters module
