### PR TITLE
SSVNetwork audit recommendations

### DIFF
--- a/contracts/SSVNetwork.sol
+++ b/contracts/SSVNetwork.sol
@@ -159,7 +159,7 @@ contract SSVNetwork is
     /*******************************/
 
     function setFeeRecipientAddress(address recipientAddress) external override {
-        emit FeeRecipientAddressUpdated(msg.sender, recipientAddress);
+        _delegate(SSVStorage.load().ssvContracts[SSVModules.SSV_OPERATORS]);
     }
 
     /*******************************/
@@ -241,6 +241,10 @@ contract SSVNetwork is
 
     function updateMinimumLiquidationCollateral(uint256 amount) external override onlyOwner {
         _delegate(SSVStorage.load().ssvContracts[SSVModules.SSV_DAO]);
+    }
+
+    function getVersion() external pure override returns (string memory version) {
+        return CoreLib.getVersion();
     }
 
     /*******************************/

--- a/contracts/SSVNetwork.sol
+++ b/contracts/SSVNetwork.sol
@@ -98,6 +98,11 @@ contract SSVNetwork is
         sp.operatorMaxFeeIncrease = operatorMaxFeeIncrease_;
     }
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
     /*****************/
     /* UUPS required */
     /*****************/

--- a/contracts/interfaces/ISSVNetwork.sol
+++ b/contracts/interfaces/ISSVNetwork.sol
@@ -26,6 +26,8 @@ interface ISSVNetwork {
         uint64 operatorMaxFeeIncrease_
     ) external;
 
+    function getVersion() external pure returns (string memory version);
+
     function updateModule(SSVModules moduleId, address moduleAddress) external;
 
     function setRegisterAuth(address userAddress, bool authOperators, bool authValidators) external;

--- a/contracts/libraries/ClusterLib.sol
+++ b/contracts/libraries/ClusterLib.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.18;
 
 import "../interfaces/ISSVNetworkCore.sol";
 import "./SSVStorage.sol";
-import "./SSVStorageProtocol.sol";
 import "./Types.sol";
 
 library ClusterLib {

--- a/contracts/libraries/CoreLib.sol
+++ b/contracts/libraries/CoreLib.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.18;
 import "./SSVStorage.sol";
 
 library CoreLib {
-    event ModuleUpgraded(SSVModules moduleId, address moduleAddress);
+    event ModuleUpgraded(SSVModules indexed moduleId, address moduleAddress);
 
     function getVersion() internal pure returns (string memory) {
         return "v1.0.0.rc2";

--- a/contracts/libraries/ProtocolLib.sol
+++ b/contracts/libraries/ProtocolLib.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.18;
 
 import "../interfaces/ISSVNetworkCore.sol";
-import "../SSVNetwork.sol";
+import "./Types.sol";
 import "./SSVStorageProtocol.sol";
 
 library ProtocolLib {

--- a/contracts/libraries/RegisterAuth.sol
+++ b/contracts/libraries/RegisterAuth.sol
@@ -1,17 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.18;
 
-import "../interfaces/ISSVNetworkCore.sol";
-import "./Types.sol";
-import "@openzeppelin/contracts/utils/Counters.sol";
-
 struct Authorization {
     bool registerOperator;
     bool registerValidator;
 }
 
 library RegisterAuth {
-    uint256 constant SSV_STORAGE_POSITION = uint256(keccak256("ssv.network.storage.auth")) - 1;
+    uint256 constant private SSV_STORAGE_POSITION = uint256(keccak256("ssv.network.storage.auth")) - 1;
 
     struct AuthData {
         mapping(address => Authorization) authorization;

--- a/contracts/libraries/SSVStorage.sol
+++ b/contracts/libraries/SSVStorage.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.18;
 
 import "../interfaces/ISSVNetworkCore.sol";
-import "./Types.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
@@ -37,7 +36,7 @@ struct StorageData {
 }
 
 library SSVStorage {
-    uint256 constant SSV_STORAGE_POSITION = uint256(keccak256("ssv.network.storage.main")) - 1;
+    uint256 constant private SSV_STORAGE_POSITION = uint256(keccak256("ssv.network.storage.main")) - 1;
 
     function load() internal pure returns (StorageData storage sd) {
         uint256 position = SSV_STORAGE_POSITION;

--- a/contracts/libraries/SSVStorageProtocol.sol
+++ b/contracts/libraries/SSVStorageProtocol.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.18;
 
-import "../interfaces/ISSVNetworkCore.sol";
-
 /// @title SSV Network Storage Protocol
 /// @notice Represents the operational settings and parameters required by the SSV Network
 struct StorageProtocol {
@@ -33,7 +31,7 @@ struct StorageProtocol {
 }
 
 library SSVStorageProtocol {
-    uint256 constant SSV_STORAGE_POSITION = uint256(keccak256("ssv.network.storage.protocol")) - 1;
+    uint256 constant private SSV_STORAGE_POSITION = uint256(keccak256("ssv.network.storage.protocol")) - 1;
 
     function load() internal pure returns (StorageProtocol storage sd) {
         uint256 position = SSV_STORAGE_POSITION;

--- a/contracts/test/libraries/CoreLibT.sol
+++ b/contracts/test/libraries/CoreLibT.sol
@@ -6,7 +6,7 @@ import "../../libraries/SSVStorage.sol";
 library CoreLibT {
 
     function getVersion() internal pure returns (string memory) {
-        return "v1.0.0";
+        return "v1.0.0.rc2";
     }
 
     function transfer(address to, uint256 amount) internal {

--- a/test/deployment/deploy.ts
+++ b/test/deployment/deploy.ts
@@ -74,7 +74,7 @@ describe('Deployment tests', () => {
             2000000,
             2000000,
             2000000,
-            2000)).to.be.revertedWith('Function must be called through delegatecall');
+            2000)).to.be.revertedWith('Initializable: contract is already initialized');
     });
 
     it('Upgrade SSVNetwork contract. Check state is only changed from proxy contract', async () => {

--- a/test/deployment/version.ts
+++ b/test/deployment/version.ts
@@ -20,7 +20,7 @@ describe('Version upgrade tests', () => {
 
         await ssvNetworkContract.updateModule(helpers.SSV_MODULES.SSV_VIEWS, viewsContract.address)
 
-        expect(await ssvNetworkViews.getVersion()).to.equal("v1.0.0");
+        expect(await ssvNetworkViews.getVersion()).to.equal("v1.0.0.rc2");
     });
 
 });

--- a/test/helpers/contract-helpers.ts
+++ b/test/helpers/contract-helpers.ts
@@ -65,7 +65,7 @@ export const DataGenerator = {
 
 export const initializeContract = async () => {
   CONFIG = {
-    initialVersion: "v1.0.0",
+    initialVersion: "v1.0.0.rc2",
     operatorMaxFeeIncrease: 1000,
     declareOperatorFeePeriod: 3600, // HOUR
     executeOperatorFeePeriod: 86400, // DAY


### PR DESCRIPTION
- [x] LIBRARIES
Set the visibility of RegisterAuth.SSV_STORAGE_POSITION to private .
Set the visibility of SSVStorage.SSV_STORAGE_POSITION to private .
Set the visibility of SSVStorageProtocol.SSV_STORAGE_POSITION to private
- [x] To facilitate logging it is recommended to index address parameters within events. Therefore the (other) address parameters in indexed keyword should be added to the CoreLib.ModuleUpgraded()
- [x] Add `getVersion` function to SSVNetwork contract

**ABI changes**
function getVersion() external pure returns (string memory version)

**Upgrade plan**

After updating SSVClusters, SSVOperators and SSVDAO, upgrade SSVNetwork.