### PR TITLE
SSVNetworkViews: Remove unused named return parameters

### DIFF
--- a/contracts/SSVNetworkViews.sol
+++ b/contracts/SSVNetworkViews.sol
@@ -39,7 +39,7 @@ contract SSVNetworkViews is UUPSUpgradeable, Ownable2StepUpgradeable, ISSVViews 
     /* Validator External View Functions */
     /*************************************/
 
-    function getValidator(address clusterOwner, bytes calldata publicKey) external view override returns (bool active) {
+    function getValidator(address clusterOwner, bytes calldata publicKey) external view override returns (bool) {
         return ssvNetwork.getValidator(clusterOwner, publicKey);
     }
 
@@ -117,20 +117,15 @@ contract SSVNetworkViews is UUPSUpgradeable, Ownable2StepUpgradeable, ISSVViews 
         return ssvNetwork.getNetworkEarnings();
     }
 
-    function getOperatorFeeIncreaseLimit() external view override returns (uint64 operatorMaxFeeIncrease) {
+    function getOperatorFeeIncreaseLimit() external view override returns (uint64) {
         return ssvNetwork.getOperatorFeeIncreaseLimit();
     }
 
-    function getMaximumOperatorFee() external view override returns (uint64 operatorMaxFee) {
+    function getMaximumOperatorFee() external view override returns (uint64) {
         return ssvNetwork.getMaximumOperatorFee();
     }
 
-    function getOperatorFeePeriods()
-        external
-        view
-        override
-        returns (uint64 declareOperatorFeePeriod, uint64 executeOperatorFeePeriod)
-    {
+    function getOperatorFeePeriods() external view override returns (uint64, uint64) {
         return ssvNetwork.getOperatorFeePeriods();
     }
 
@@ -150,7 +145,7 @@ contract SSVNetworkViews is UUPSUpgradeable, Ownable2StepUpgradeable, ISSVViews 
         return ssvNetwork.getNetworkValidatorsCount();
     }
 
-    function getVersion() external view override returns (string memory version) {
+    function getVersion() external view override returns (string memory) {
         return ssvNetwork.getVersion();
     }
 }

--- a/contracts/interfaces/ISSVViews.sol
+++ b/contracts/interfaces/ISSVViews.sol
@@ -8,7 +8,7 @@ interface ISSVViews is ISSVNetworkCore {
     /// @param owner The address of the validator's owner
     /// @param publicKey The public key of the validator
     /// @return active A boolean indicating if the validator is active. If it does not exist, returns false.
-    function getValidator(address owner, bytes calldata publicKey) external view returns (bool active);
+    function getValidator(address owner, bytes calldata publicKey) external view returns (bool);
 
     /// @notice Gets the operator fee
     /// @param operatorId The ID of the operator
@@ -94,20 +94,17 @@ interface ISSVViews is ISSVNetworkCore {
     function getNetworkEarnings() external view returns (uint256 networkEarnings);
 
     /// @notice Gets the operator fee increase limit
-    /// @return operatorMaxFeeIncrease The maximum limit of operator fee increase
-    function getOperatorFeeIncreaseLimit() external view returns (uint64 operatorMaxFeeIncrease);
+    /// @return The maximum limit of operator fee increase
+    function getOperatorFeeIncreaseLimit() external view returns (uint64);
 
     /// @notice Gets the operator maximum fee for operators that use SSV token
-    /// @return operatorMaxFee The maximum fee value (SSV)
-    function getMaximumOperatorFee() external view returns (uint64 operatorMaxFee);
+    /// @return The maximum fee value (SSV)
+    function getMaximumOperatorFee() external view returns (uint64);
 
     /// @notice Gets the periods of operator fee declaration and execution
-    /// @return declareOperatorFeePeriod The period for declaring operator fee
-    /// @return executeOperatorFeePeriod The period for executing operator fee
-    function getOperatorFeePeriods()
-        external
-        view
-        returns (uint64 declareOperatorFeePeriod, uint64 executeOperatorFeePeriod);
+    /// @return The period for declaring operator fee
+    /// @return The period for executing operator fee
+    function getOperatorFeePeriods() external view returns (uint64, uint64);
 
     /// @notice Gets the liquidation threshold period
     /// @return blocks The number of blocks for the liquidation threshold period
@@ -126,6 +123,6 @@ interface ISSVViews is ISSVNetworkCore {
     function getNetworkValidatorsCount() external view returns (uint32 validatorsCount);
 
     /// @notice Gets the version of the contract
-    /// @return version The version of the contract
-    function getVersion() external view returns (string memory version);
+    /// @return The version of the contract
+    function getVersion() external view returns (string memory);
 }

--- a/contracts/modules/SSVViews.sol
+++ b/contracts/modules/SSVViews.sol
@@ -21,21 +21,20 @@ contract SSVViews is ISSVViews {
     /* Validator External View Functions */
     /*************************************/
 
-    function getValidator(address clusterOwner, bytes calldata publicKey) external view override returns (bool active) {
+    function getValidator(address clusterOwner, bytes calldata publicKey) external view override returns (bool) {
         bytes32 validatorData = SSVStorage.load().validatorPKs[keccak256(abi.encodePacked(publicKey, clusterOwner))];
 
         if (validatorData == bytes32(0)) return false;
         bytes32 activeFlag = validatorData & bytes32(uint256(1)); // Retrieve LSB of stored value
 
         return activeFlag == bytes32(uint256(1));
-
     }
 
     /************************************/
     /* Operator External View Functions */
     /************************************/
 
-    function getOperatorFee(uint64 operatorId) external view override returns (uint256 fee) {
+    function getOperatorFee(uint64 operatorId) external view override returns (uint256) {
         return SSVStorage.load().operators[operatorId].fee.expand();
     }
 
@@ -172,20 +171,15 @@ contract SSVViews is ISSVViews {
         return SSVStorageProtocol.load().networkTotalEarnings().expand();
     }
 
-    function getOperatorFeeIncreaseLimit() external view override returns (uint64 operatorMaxFeeIncrease) {
+    function getOperatorFeeIncreaseLimit() external view override returns (uint64) {
         return SSVStorageProtocol.load().operatorMaxFeeIncrease;
     }
 
-    function getMaximumOperatorFee() external view override returns (uint64 operatorMaxFee) {
+    function getMaximumOperatorFee() external view override returns (uint64) {
         return SSVStorageProtocol.load().operatorMaxFee;
     }
 
-    function getOperatorFeePeriods()
-        external
-        view
-        override
-        returns (uint64 declareOperatorFeePeriod, uint64 executeOperatorFeePeriod)
-    {
+    function getOperatorFeePeriods() external view override returns (uint64, uint64) {
         return (SSVStorageProtocol.load().declareOperatorFeePeriod, SSVStorageProtocol.load().executeOperatorFeePeriod);
     }
 
@@ -205,7 +199,7 @@ contract SSVViews is ISSVViews {
         return SSVStorageProtocol.load().daoValidatorCount;
     }
 
-    function getVersion() external pure override returns (string memory version) {
+    function getVersion() external pure override returns (string memory) {
         return CoreLib.getVersion();
     }
 }


### PR DESCRIPTION
SSV-6 
Gas Optimization: Wasted Deployment Gas From Unused Named Return
