### PR TITLE
Support validator EB increase

### DIFF
--- a/contracts/SSVNetwork.sol
+++ b/contracts/SSVNetwork.sol
@@ -271,6 +271,17 @@ contract SSVNetwork is
         _delegate(SSVStorage.load().ssvContracts[SSVModules.SSV_CLUSTERS]);
     }
 
+    function updateClusterBalance(
+        uint64 blockNum,
+        address clusterOwner,
+        uint64[] calldata operatorIds,
+        ISSVNetworkCore.Cluster memory cluster,
+        uint256 effectiveBalance,
+        bytes32[] calldata merkleProof
+    ) external override {
+        _delegate(SSVStorage.load().ssvContracts[SSVModules.SSV_CLUSTERS]);
+    }
+
     function exitValidator(bytes calldata publicKey, uint64[] calldata operatorIds) external override {
         _delegate(SSVStorage.load().ssvContracts[SSVModules.SSV_CLUSTERS]);
     }
@@ -308,6 +319,10 @@ contract SSVNetwork is
     }
 
     function updateMaximumOperatorFee(uint64 maxFee) external override onlyOwner {
+        _delegate(SSVStorage.load().ssvContracts[SSVModules.SSV_DAO]);
+    }
+
+    function commitRoot(bytes32 merkleRoot, uint64 blockNum) external override {
         _delegate(SSVStorage.load().ssvContracts[SSVModules.SSV_DAO]);
     }
 

--- a/contracts/SSVNetwork.sol
+++ b/contracts/SSVNetwork.sol
@@ -326,6 +326,15 @@ contract SSVNetwork is
         _delegate(SSVStorage.load().ssvContracts[SSVModules.SSV_DAO]);
     }
 
+    function setOracleTimingConfig(
+        uint64 firstStartEpoch,
+        uint64 firstInterval,
+        uint64 secondStartEpoch,
+        uint64 secondInterval
+    ) external onlyOwner {
+        _delegate(SSVStorage.load().ssvContracts[SSVModules.SSV_DAO]);
+    }
+
     function getVersion() external pure override returns (string memory version) {
         return CoreLib.getVersion();
     }

--- a/contracts/SSVNetworkViews.sol
+++ b/contracts/SSVNetworkViews.sol
@@ -164,6 +164,21 @@ contract SSVNetworkViews is UUPSUpgradeable, Ownable2StepUpgradeable, ISSVViews 
         return ssvNetwork.getNetworkValidatorsCount();
     }
 
+    function getOracleTimingConfig(
+        uint64 referenceEpoch
+    ) external view returns (uint64 startEpoch, uint64 epochInterval) {
+        return ssvNetwork.getOracleTimingConfig(referenceEpoch);
+    }
+
+
+    function getTargetEpoch(
+        uint64 round,
+        uint64 startEpoch,
+        uint64 epochInterval
+    ) external view returns (uint64) {
+        return ssvNetwork.getTargetEpoch(round, startEpoch, epochInterval);
+    }
+
     function getVersion() external view override returns (string memory) {
         return ssvNetwork.getVersion();
     }

--- a/contracts/interfaces/ISSVClusters.sol
+++ b/contracts/interfaces/ISSVClusters.sol
@@ -82,6 +82,15 @@ interface ISSVClusters is ISSVNetworkCore {
     /// @param cluster Cluster where the withdrawal will be made
     function withdraw(uint64[] memory operatorIds, uint256 tokenAmount, Cluster memory cluster) external;
 
+    function updateClusterBalance(
+        uint64 blockNum,
+        address clusterOwner,
+        uint64[] calldata operatorIds,
+        Cluster memory cluster,
+        uint256 effectiveBalance,
+        bytes32[] calldata merkleProof
+    ) external;
+
     /// @notice Fires the exit event for a validator
     /// @param publicKey The public key of the validator to be exited
     /// @param operatorIds Array of IDs of operators managing the validator
@@ -142,6 +151,8 @@ interface ISSVClusters is ISSVNetworkCore {
      * @param cluster The cluster into which SSV tokens were deposited.
      */
     event ClusterDeposited(address indexed owner, uint64[] operatorIds, uint256 value, Cluster cluster);
+
+    event ClusterBalanceUpdated(bytes32 indexed clusterId, uint64 indexed blockNum, uint256 effectiveBalance, uint64 vUnits);
 
     /**
      * @dev Emitted when a validator begins the exit process.

--- a/contracts/interfaces/ISSVClusters.sol
+++ b/contracts/interfaces/ISSVClusters.sol
@@ -4,6 +4,13 @@ pragma solidity ^0.8.20;
 import {ISSVNetworkCore} from "./ISSVNetworkCore.sol";
 
 interface ISSVClusters is ISSVNetworkCore {
+    struct UpdateCtx {
+        bytes32 clusterId;
+        uint64 blockNum;
+        uint256 effectiveBalance;
+        bytes32[] merkleProof;
+    }
+
     /// @notice Registers a new validator on the SSV Network
     /// @param publicKey The public key of the new validator
     /// @param operatorIds Array of IDs of operators managing this validator

--- a/contracts/interfaces/ISSVDAO.sol
+++ b/contracts/interfaces/ISSVDAO.sol
@@ -41,6 +41,13 @@ interface ISSVDAO is ISSVNetworkCore {
     /// @param blockNum Block number when oracle computed this data (must be finalized and strictly increasing)
     function commitRoot(bytes32 merkleRoot, uint64 blockNum) external;
 
+    function setOracleTimingConfig(
+        uint64 firstStartEpoch,
+        uint64 firstInterval,
+        uint64 secondStartEpoch,
+        uint64 secondInterval
+    ) external;
+
     event OperatorFeeIncreaseLimitUpdated(uint64 value);
 
     event DeclareOperatorFeePeriodUpdated(uint64 value);

--- a/contracts/interfaces/ISSVDAO.sol
+++ b/contracts/interfaces/ISSVDAO.sol
@@ -36,6 +36,11 @@ interface ISSVDAO is ISSVNetworkCore {
     /// @param maxFee The new maximum fee (SSV)
     function updateMaximumOperatorFee(uint64 maxFee) external;
 
+    /// @notice Commit Merkle root of all cluster EBs
+    /// @param merkleRoot Root of Merkle tree containing all cluster EBs
+    /// @param blockNum Block number when oracle computed this data (must be finalized and strictly increasing)
+    function commitRoot(bytes32 merkleRoot, uint64 blockNum) external;
+
     event OperatorFeeIncreaseLimitUpdated(uint64 value);
 
     event DeclareOperatorFeePeriodUpdated(uint64 value);
@@ -61,4 +66,10 @@ interface ISSVDAO is ISSVNetworkCore {
     event NetworkEarningsWithdrawn(uint256 value, address recipient);
 
     event OperatorMaximumFeeUpdated(uint64 maxFee);
+
+    /// @notice Emitted when an EB Merkle root is committed for a given block
+    /// @param merkleRoot The committed Merkle root
+    /// @param blockNum The block number the root corresponds to
+    /// @param timestamp The timestamp of the commit transaction
+    event RootCommitted(bytes32 indexed merkleRoot, uint64 indexed blockNum, uint256 timestamp);
 }

--- a/contracts/interfaces/ISSVNetworkCore.sol
+++ b/contracts/interfaces/ISSVNetworkCore.sol
@@ -95,6 +95,7 @@ interface ISSVNetworkCore {
     error InvalidWhitelistingContract(address contractAddress); // 0x886e6a03
     error InvalidWhitelistAddressesLength(); // 0xcbb362dc
     error ZeroAddressNotAllowed(); // 0x8579befe
+    error EpochOverflow();
 
     // EB oracle-specific errors
     error StaleBlockNumber();
@@ -105,6 +106,7 @@ interface ISSVNetworkCore {
     error InvalidProof();
     error EBExceedsMaximum();
     error NotAuthorizedOracle();
+    error ZeroInterval();
 
     // legacy errors
     error ValidatorAlreadyExists(); // 0x8d09a73e

--- a/contracts/interfaces/ISSVNetworkCore.sol
+++ b/contracts/interfaces/ISSVNetworkCore.sol
@@ -96,6 +96,16 @@ interface ISSVNetworkCore {
     error InvalidWhitelistAddressesLength(); // 0xcbb362dc
     error ZeroAddressNotAllowed(); // 0x8579befe
 
+    // EB oracle-specific errors
+    error StaleBlockNumber();
+    error FutureBlockNumber();
+    error RootNotFound();
+    error UpdateTooFrequent();
+    error StaleUpdate();
+    error InvalidProof();
+    error EBExceedsMaximum();
+    error NotAuthorizedOracle();
+
     // legacy errors
     error ValidatorAlreadyExists(); // 0x8d09a73e
     error IncorrectValidatorState(); // 0x2feda3c1

--- a/contracts/interfaces/ISSVViews.sol
+++ b/contracts/interfaces/ISSVViews.sol
@@ -155,6 +155,17 @@ interface ISSVViews is ISSVNetworkCore {
     /// @return validatorsCount The total number of validators in the network
     function getNetworkValidatorsCount() external view returns (uint32 validatorsCount);
 
+    function getOracleTimingConfig(
+        uint64 referenceEpoch
+    ) external view returns (uint64 startEpoch, uint64 epochInterval);
+
+
+    function getTargetEpoch(
+        uint64 round,
+        uint64 startEpoch,
+        uint64 epochInterval
+    ) external view returns (uint64);
+
     /// @notice Gets the version of the contract
     /// @return The version of the contract
     function getVersion() external view returns (string memory);

--- a/contracts/libraries/ClusterLib.sol
+++ b/contracts/libraries/ClusterLib.sol
@@ -63,10 +63,11 @@ library ClusterLib {
 
     function updateClusterData(
         ISSVNetworkCore.Cluster memory cluster,
+        bytes32 clusterId,
         uint64 clusterIndex,
         uint64 currentNetworkFeeIndex
-    ) internal pure {
-        updateBalance(cluster, clusterIndex, currentNetworkFeeIndex);
+    ) internal view {
+        updateBalanceWithEB(cluster, clusterId, clusterIndex, currentNetworkFeeIndex);
         cluster.index = clusterIndex;
         cluster.networkFeeIndex = currentNetworkFeeIndex;
     }
@@ -124,15 +125,16 @@ library ClusterLib {
             sp
         );
 
-        updateClusterData(cluster, clusterIndex, sp.currentNetworkFeeIndex());
+        updateClusterData(cluster, hashedCluster, clusterIndex, sp.currentNetworkFeeIndex());
 
         sp.updateDAO(true, validatorCountDelta);
 
         cluster.validatorCount += validatorCountDelta;
 
         if (
-            isLiquidatable(
+            isLiquidatableWithEB(
                 cluster,
+                hashedCluster,
                 burnRate,
                 sp.networkFee,
                 sp.minimumBlocksBeforeLiquidation,
@@ -150,7 +152,10 @@ library ClusterLib {
         uint64 vUnits = seb.clusterEB[clusterId].vUnits;
 
         if (vUnits == 0) {
-            return uint64(validatorCount);
+            // Before any EB is set for this cluster, approximate EB as 32 ETH per validator.
+            // To preserve legacy accounting, we treat each validator as 1 logical vUnit (32 ETH),
+            // scaled by VUNITS_PRECISION for fixed-point arithmetic.
+            return uint64(validatorCount) * VUNITS_PRECISION;
         }
 
         return vUnits;

--- a/contracts/libraries/ClusterLib.sol
+++ b/contracts/libraries/ClusterLib.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.24;
 import "../interfaces/ISSVNetworkCore.sol";
 import {StorageData} from "./SSVStorage.sol";
 import {StorageProtocol} from "./SSVStorageProtocol.sol";
+import {SSVStorageEB, StorageEB, VUNITS_PRECISION} from "./SSVStorageEB.sol";
 import "./OperatorLib.sol";
 import "./ProtocolLib.sol";
 import {Types64} from "./Types.sol";
@@ -142,5 +143,54 @@ library ClusterLib {
         }
 
         s.clusters[hashedCluster] = hashClusterData(cluster);
+    }
+
+    function getVUnits(bytes32 clusterId, uint32 validatorCount) internal view returns (uint64) {
+        StorageEB storage seb = SSVStorageEB.load();
+        uint64 vUnits = seb.clusterEB[clusterId].vUnits;
+
+        if (vUnits == 0) {
+            return uint64(validatorCount);
+        }
+
+        return vUnits;
+    }
+
+    function updateBalanceWithEB(
+        ISSVNetworkCore.Cluster memory cluster,
+        bytes32 clusterId,
+        uint64 newIndex,
+        uint64 currentNetworkFeeIndex
+    ) internal view {
+        uint64 vUnits = getVUnits(clusterId, cluster.validatorCount);
+        uint128 units = vUnits;
+        uint128 idxNet = currentNetworkFeeIndex - cluster.networkFeeIndex;
+        uint128 idxOp = newIndex - cluster.index;
+
+        uint128 networkFeeUnits = (idxNet * units) / VUNITS_PRECISION;
+        uint128 usageUnits = (idxOp * units) / VUNITS_PRECISION + networkFeeUnits;
+
+        uint64 usage = uint64(usageUnits);
+        cluster.balance = usage.expand() > cluster.balance ? 0 : cluster.balance - usage.expand();
+    }
+
+    function isLiquidatableWithEB(
+        ISSVNetworkCore.Cluster memory cluster,
+        bytes32 clusterId,
+        uint64 burnRate,
+        uint64 networkFee,
+        uint64 minimumBlocksBeforeLiquidation,
+        uint64 minimumLiquidationCollateral
+    ) internal view returns (bool liquidatable) {
+        if (cluster.validatorCount == 0) return false;
+        if (cluster.balance < minimumLiquidationCollateral.expand()) return true;
+
+        uint64 vUnits = getVUnits(clusterId, cluster.validatorCount);
+        uint128 units = vUnits;
+        uint128 rate = burnRate + networkFee;
+        uint128 thresholdUnits = (uint128(minimumBlocksBeforeLiquidation) * rate * units) / VUNITS_PRECISION;
+
+        uint64 liquidationThreshold = uint64(thresholdUnits);
+        return cluster.balance < liquidationThreshold.expand();
     }
 }

--- a/contracts/libraries/OperatorLib.sol
+++ b/contracts/libraries/OperatorLib.sol
@@ -5,6 +5,7 @@ import "../interfaces/ISSVNetworkCore.sol";
 import {ISSVWhitelistingContract} from "../interfaces/external/ISSVWhitelistingContract.sol";
 import {StorageData} from "./SSVStorage.sol";
 import {StorageProtocol} from "./SSVStorageProtocol.sol";
+import {SSVStorageEB, StorageEB, VUNITS_PRECISION} from "./SSVStorageEB.sol";
 import {Types64} from "./Types.sol";
 
 import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
@@ -12,19 +13,52 @@ import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 library OperatorLib {
     using Types64 for uint64;
 
-    function updateSnapshot(ISSVNetworkCore.Operator memory operator) internal view {
+    function updateSnapshot(
+        ISSVNetworkCore.Operator memory operator,
+        uint64 operatorId,
+        StorageEB storage seb
+    ) internal view {
         uint64 blockDiffFee = (uint32(block.number) - operator.snapshot.block) * operator.fee;
 
+        // Accounting model:
+        // - After EB is set for this operator: earnings are proportional to total EB:
+        //     earnings_per_block = fee * (totalEB / 32 ether)
+        //   where seb.operatorVUnits[operatorId] stores (totalEB / 32 ether) * VUNITS_PRECISION.
+        // - Before any EB is set (operatorVUnits == 0 but validatorCount > 0):
+        //   approximate totalEB ≈ validatorCount * 32 ether and preserve legacy behavior by
+        //   treating each validator as 1 logical vUnit scaled by VUNITS_PRECISION.
+        uint64 vUnits = seb.operatorVUnits[operatorId];
+        if (vUnits == 0 && operator.validatorCount > 0) {
+            vUnits = operator.validatorCount * VUNITS_PRECISION;
+        }
+
         operator.snapshot.index += blockDiffFee;
-        operator.snapshot.balance += blockDiffFee * operator.validatorCount;
+        if (vUnits != 0 && blockDiffFee != 0) {
+            uint128 units = vUnits;
+            uint128 delta = (uint128(blockDiffFee) * units) / VUNITS_PRECISION;
+            operator.snapshot.balance += uint64(delta);
+        }
         operator.snapshot.block = uint32(block.number);
     }
 
-    function updateSnapshotSt(ISSVNetworkCore.Operator storage operator) internal {
+    function updateSnapshotSt(
+        ISSVNetworkCore.Operator storage operator,
+        uint64 operatorId,
+        StorageEB storage seb
+    ) internal {
         uint64 blockDiffFee = (uint32(block.number) - operator.snapshot.block) * operator.fee;
 
+        uint64 vUnits = seb.operatorVUnits[operatorId];
+        if (vUnits == 0 && operator.validatorCount > 0) {
+            vUnits = operator.validatorCount * VUNITS_PRECISION;
+        }
+
         operator.snapshot.index += blockDiffFee;
-        operator.snapshot.balance += blockDiffFee * operator.validatorCount;
+        if (vUnits != 0 && blockDiffFee != 0) {
+            uint128 units = vUnits;
+            uint128 delta = (uint128(blockDiffFee) * units) / VUNITS_PRECISION;
+            operator.snapshot.balance += uint64(delta);
+        }
         operator.snapshot.block = uint32(block.number);
     }
 
@@ -40,6 +74,7 @@ library OperatorLib {
         StorageProtocol storage sp
     ) internal returns (uint64 cumulativeIndex, uint64 cumulativeFee) {
         uint256 operatorsLength = operatorIds.length;
+        StorageEB storage seb = SSVStorageEB.load();
 
         uint256 blockIndex;
         uint256 lastBlockIndex = ~uint256(0); // Use an invalid block index as the initial value
@@ -91,7 +126,7 @@ library OperatorLib {
                 }
             }
 
-            updateSnapshot(operator);
+            updateSnapshot(operator, operatorId, seb);
             if ((operator.validatorCount += deltaValidatorCount) > sp.validatorsPerOperatorLimit) {
                 revert ISSVNetworkCore.ExceedValidatorLimitWithData(operatorId);
             }
@@ -111,6 +146,7 @@ library OperatorLib {
         StorageProtocol storage sp
     ) internal returns (uint64 cumulativeIndex, uint64 cumulativeFee) {
         uint256 operatorsLength = operatorIds.length;
+        StorageEB storage seb = SSVStorageEB.load();
 
         for (uint256 i; i < operatorsLength; ++i) {
             uint64 operatorId = operatorIds[i];
@@ -118,7 +154,7 @@ library OperatorLib {
             ISSVNetworkCore.Operator storage operator = s.operators[operatorId];
 
             if (operator.snapshot.block != 0) {
-                updateSnapshotSt(operator);
+                updateSnapshotSt(operator, operatorId, seb);
                 if (!increaseValidatorCount) {
                     operator.validatorCount -= deltaValidatorCount;
                 } else if ((operator.validatorCount += deltaValidatorCount) > sp.validatorsPerOperatorLimit) {

--- a/contracts/libraries/ProtocolLib.sol
+++ b/contracts/libraries/ProtocolLib.sol
@@ -47,14 +47,15 @@ library ProtocolLib {
         uint32 deltaValidatorCount
     ) internal {
         updateDAOEarnings(sp);
+        uint64 deltaVUnits = uint64(deltaValidatorCount) * VUNITS_PRECISION;
         if (!increaseValidatorCount) {
             sp.daoValidatorCount -= deltaValidatorCount;
-            sp.daoTotalVUnits -= deltaValidatorCount;
+            sp.daoTotalVUnits -= deltaVUnits;
         } else {
             if ((sp.daoValidatorCount += deltaValidatorCount) > type(uint32).max) {
                 revert ISSVNetworkCore.MaxValueExceeded();
             }
-            sp.daoTotalVUnits += deltaValidatorCount;
+            sp.daoTotalVUnits += deltaVUnits;
         }
     }
 }

--- a/contracts/libraries/ProtocolLib.sol
+++ b/contracts/libraries/ProtocolLib.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.24;
 import "../interfaces/ISSVNetworkCore.sol";
 import {Types256} from "./Types.sol";
 import {StorageProtocol} from "./SSVStorageProtocol.sol";
+import {VUNITS_PRECISION} from "./SSVStorageEB.sol";
 
 library ProtocolLib {
     using Types256 for uint256;
@@ -32,15 +33,28 @@ library ProtocolLib {
     }
 
     function networkTotalEarnings(StorageProtocol storage sp) internal view returns (uint64) {
-        return sp.daoBalance + (uint64(block.number) - sp.daoIndexBlockNumber) * sp.networkFee * sp.daoValidatorCount;
+        uint128 units = sp.daoTotalVUnits;
+        uint128 idx = uint64(block.number) - sp.daoIndexBlockNumber;
+        uint128 fee = sp.networkFee;
+
+        uint128 earningsUnits = (idx * fee * units) / VUNITS_PRECISION;
+        return sp.daoBalance + uint64(earningsUnits);
     }
 
-    function updateDAO(StorageProtocol storage sp, bool increaseValidatorCount, uint32 deltaValidatorCount) internal {
+    function updateDAO(
+        StorageProtocol storage sp,
+        bool increaseValidatorCount,
+        uint32 deltaValidatorCount
+    ) internal {
         updateDAOEarnings(sp);
         if (!increaseValidatorCount) {
             sp.daoValidatorCount -= deltaValidatorCount;
-        } else if ((sp.daoValidatorCount += deltaValidatorCount) > type(uint32).max) {
-            revert ISSVNetworkCore.MaxValueExceeded();
+            sp.daoTotalVUnits -= deltaValidatorCount;
+        } else {
+            if ((sp.daoValidatorCount += deltaValidatorCount) > type(uint32).max) {
+                revert ISSVNetworkCore.MaxValueExceeded();
+            }
+            sp.daoTotalVUnits += deltaValidatorCount;
         }
     }
 }

--- a/contracts/libraries/SSVStorageEB.sol
+++ b/contracts/libraries/SSVStorageEB.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.24;
+
+uint64 constant VUNITS_PRECISION = 100;
+uint256 constant MAX_EB_PER_VALIDATOR = 2048 ether;
+uint256 constant DEFAULT_EB_PER_VALIDATOR = 32 ether;
+
+struct ClusterEBSnapshot {
+    uint64 vUnits;
+    uint64 lastRootBlockNum;
+    uint64 lastUpdateBlock;
+}
+
+struct StorageEB {
+    /// @notice Maps block to EB roots
+    mapping(uint64 => bytes32) ebRoots;
+    /// @notice Maps cluster ID to EB snapshot
+    mapping(bytes32 => ClusterEBSnapshot) clusterEB;
+    /// @notice Maps operator ID to vUnits
+    mapping(uint64 => uint64) operatorVUnits;
+    /// @notice Latest block number where EB was committed
+    uint64 latestCommittedBlock;
+    /// @notice Minimum blocks between updates
+    uint32 minBlocksBetweenUpdates;
+}
+
+library SSVStorageEB {
+    uint256 private constant SSV_STORAGE_POSITION = uint256(keccak256("ssv.network.storage.eb")) - 1;
+
+    function load() internal pure returns (StorageEB storage seb) {
+        uint256 position = SSV_STORAGE_POSITION;
+        assembly {
+            seb.slot := position
+        }
+    }
+}

--- a/contracts/libraries/SSVStorageProtocol.sol
+++ b/contracts/libraries/SSVStorageProtocol.sol
@@ -32,6 +32,14 @@ struct StorageProtocol {
     uint64 operatorMaxFee;
     /// @notice The current total vUnits of the DAO
     uint64 daoTotalVUnits;
+    /// @notice First-phase oracle start epoch (firstStartEpoch)
+    uint64 oracleFirstStartEpoch;
+    /// @notice First-phase oracle interval in epochs (firstInterval), must be > 0
+    uint64 oracleFirstEpochInterval;
+    /// @notice Second-phase oracle start epoch (secondStartEpoch)
+    uint64 oracleSecondStartEpoch;
+    /// @notice Second-phase oracle interval in epochs (secondInterval), must be > 0
+    uint64 oracleSecondEpochInterval;
 }
 
 library SSVStorageProtocol {

--- a/contracts/libraries/SSVStorageProtocol.sol
+++ b/contracts/libraries/SSVStorageProtocol.sol
@@ -30,6 +30,8 @@ struct StorageProtocol {
     uint64 operatorMaxFeeIncrease;
     /// @notice The maximum value in operator fee that is allowed (SSV)
     uint64 operatorMaxFee;
+    /// @notice The current total vUnits of the DAO
+    uint64 daoTotalVUnits;
 }
 
 library SSVStorageProtocol {

--- a/contracts/modules/SSVClusters.sol
+++ b/contracts/modules/SSVClusters.sol
@@ -43,7 +43,14 @@ contract SSVClusters is ISSVClusters {
             StorageEB storage seb = SSVStorageEB.load();
             ClusterEBSnapshot storage ebSnapshot = seb.clusterEB[hashedCluster];
             if (ebSnapshot.vUnits > 0) {
-                ebSnapshot.vUnits += 1;
+                uint64 deltaClusterVUnits = VUNITS_PRECISION;
+                ebSnapshot.vUnits += deltaClusterVUnits;
+
+                uint256 operatorsLength = operatorIds.length;
+                for (uint256 i; i < operatorsLength; ++i) {
+                    uint64 operatorId = operatorIds[i];
+                    seb.operatorVUnits[operatorId] += deltaClusterVUnits;
+                }
             }
         }
 
@@ -84,7 +91,14 @@ contract SSVClusters is ISSVClusters {
             StorageEB storage seb = SSVStorageEB.load();
             ClusterEBSnapshot storage ebSnapshot = seb.clusterEB[hashedCluster];
             if (ebSnapshot.vUnits > 0) {
-                ebSnapshot.vUnits += uint64(validatorsLength);
+                uint64 deltaClusterVUnits = uint64(validatorsLength) * VUNITS_PRECISION;
+                ebSnapshot.vUnits += deltaClusterVUnits;
+
+                uint256 operatorsLength = operatorIds.length;
+                for (uint256 i; i < operatorsLength; ++i) {
+                    uint64 operatorId = operatorIds[i];
+                    seb.operatorVUnits[operatorId] += deltaClusterVUnits;
+                }
             }
         }
 
@@ -126,7 +140,7 @@ contract SSVClusters is ISSVClusters {
             StorageProtocol storage sp = SSVStorageProtocol.load();
             (uint64 clusterIndex, ) = OperatorLib.updateClusterOperators(operatorIds, false, 1, s, sp);
 
-            cluster.updateClusterData(clusterIndex, sp.currentNetworkFeeIndex());
+            cluster.updateClusterData(hashedCluster, clusterIndex, sp.currentNetworkFeeIndex());
 
             sp.updateDAO(false, 1);
         }
@@ -137,7 +151,14 @@ contract SSVClusters is ISSVClusters {
             StorageEB storage seb = SSVStorageEB.load();
             ClusterEBSnapshot storage ebSnapshot = seb.clusterEB[hashedCluster];
             if (ebSnapshot.vUnits > 0) {
-                ebSnapshot.vUnits -= 1;
+                uint64 deltaClusterVUnits = VUNITS_PRECISION;
+                ebSnapshot.vUnits -= deltaClusterVUnits;
+
+                uint256 operatorsLength = operatorIds.length;
+                for (uint256 i; i < operatorsLength; ++i) {
+                    uint64 operatorId = operatorIds[i];
+                    seb.operatorVUnits[operatorId] -= deltaClusterVUnits;
+                }
             }
         }
 
@@ -181,7 +202,7 @@ contract SSVClusters is ISSVClusters {
             StorageProtocol storage sp = SSVStorageProtocol.load();
             (uint64 clusterIndex, ) = OperatorLib.updateClusterOperators(operatorIds, false, validatorsRemoved, s, sp);
 
-            cluster.updateClusterData(clusterIndex, sp.currentNetworkFeeIndex());
+            cluster.updateClusterData(hashedCluster, clusterIndex, sp.currentNetworkFeeIndex());
 
             sp.updateDAO(false, validatorsRemoved);
         }
@@ -192,7 +213,14 @@ contract SSVClusters is ISSVClusters {
             StorageEB storage seb = SSVStorageEB.load();
             ClusterEBSnapshot storage ebSnapshot = seb.clusterEB[hashedCluster];
             if (ebSnapshot.vUnits > 0) {
-                ebSnapshot.vUnits -= validatorsRemoved;
+                uint64 deltaClusterVUnits = uint64(validatorsRemoved) * VUNITS_PRECISION;
+                ebSnapshot.vUnits -= deltaClusterVUnits;
+
+                uint256 operatorsLength = operatorIds.length;
+                for (uint256 i; i < operatorsLength; ++i) {
+                    uint64 operatorId = operatorIds[i];
+                    seb.operatorVUnits[operatorId] -= deltaClusterVUnits;
+                }
             }
         }
 
@@ -239,6 +267,46 @@ contract SSVClusters is ISSVClusters {
         }
 
         sp.updateDAO(false, cluster.validatorCount);
+
+        // EB accounting on liquidation:
+        // - Remove this cluster's EB units from DAO totals (beyond the baseline 1 vUnit per validator
+        //   already handled by updateDAO).
+        // - Remove this cluster's EB contribution from each operator's operatorVUnits.
+        // - Reset the cluster's EB snapshot vUnits to zero so future EB-aware helpers fall back
+        //   to validatorCount until a new EB is reported.
+        {
+            StorageEB storage seb = SSVStorageEB.load();
+            ClusterEBSnapshot storage ebSnapshot = seb.clusterEB[hashedCluster];
+            uint64 vUnitsCluster = ebSnapshot.vUnits;
+            if (vUnitsCluster > 0) {
+                // Adjust DAO total vUnits so that the net effect of liquidation is to remove
+                // the full cluster EB units vUnitsCluster from daoTotalVUnits.
+                uint64 baselineVUnits = uint64(cluster.validatorCount) * VUNITS_PRECISION;
+                if (vUnitsCluster != baselineVUnits) {
+                    bool moreThanBaseline = vUnitsCluster > baselineVUnits;
+                    uint64 delta = moreThanBaseline
+                        ? vUnitsCluster - baselineVUnits
+                        : baselineVUnits - vUnitsCluster;
+                    if (delta != 0) {
+                        if (moreThanBaseline) {
+                            sp.daoTotalVUnits -= delta;
+                        } else {
+                            sp.daoTotalVUnits += delta;
+                        }
+                    }
+                }
+
+                // Remove this cluster's EB units from each operator in the cluster.
+                uint256 operatorsLength = operatorIds.length;
+                for (uint256 i; i < operatorsLength; ++i) {
+                    uint64 operatorId = operatorIds[i];
+                    seb.operatorVUnits[operatorId] -= vUnitsCluster;
+                }
+
+                // Reset cluster EB units to zero (root metadata is kept for staleness checks).
+                ebSnapshot.vUnits = 0;
+            }
+        }
 
         if (cluster.balance != 0) {
             balanceLiquidatable = cluster.balance;
@@ -441,12 +509,14 @@ contract SSVClusters is ISSVClusters {
             revert EBExceedsMaximum();
         }
 
-        uint64 oldVUnits = ebSnapshot.vUnits;
+        uint64 storedVUnits = ebSnapshot.vUnits;
+        uint64 oldVUnits = storedVUnits;
         if (oldVUnits == 0) {
-            oldVUnits = uint64(cluster.validatorCount);
+            oldVUnits = uint64(cluster.validatorCount) * VUNITS_PRECISION;
         }
 
         uint64 newVUnits = uint64((effectiveBalance * VUNITS_PRECISION) / 32 ether);
+
         {
             if (cluster.active) {
                 (uint64 clusterIndex, ) = OperatorLib.updateClusterOperators(operatorIds, false, 0, s, sp);
@@ -476,6 +546,30 @@ contract SSVClusters is ISSVClusters {
                 }
             }
         }
+
+        // Update operatorVUnits for each operator based on the change in cluster vUnits.
+        if (newVUnits != storedVUnits) {
+            bool deltaPositive = newVUnits > storedVUnits;
+            uint256 deltaClusterVUnits = deltaPositive
+                ? uint256(newVUnits) - uint256(storedVUnits)
+                : uint256(storedVUnits) - uint256(newVUnits);
+
+            if (deltaClusterVUnits != 0) {
+                uint64 deltaAbs = uint64(deltaClusterVUnits);
+                if (deltaAbs != 0) {
+                    uint256 operatorsLength = operatorIds.length;
+                    for (uint256 i; i < operatorsLength; ++i) {
+                        uint64 operatorId = operatorIds[i];
+                        if (deltaPositive) {
+                            seb.operatorVUnits[operatorId] += deltaAbs;
+                        } else {
+                            seb.operatorVUnits[operatorId] -= deltaAbs;
+                        }
+                    }
+                }
+            }
+        }
+
         ebSnapshot.vUnits = newVUnits;
         ebSnapshot.lastRootBlockNum = blockNum;
         ebSnapshot.lastUpdateBlock = uint64(block.number);

--- a/contracts/modules/SSVClusters.sol
+++ b/contracts/modules/SSVClusters.sol
@@ -477,77 +477,156 @@ contract SSVClusters is ISSVClusters {
         uint256 effectiveBalance,
         bytes32[] calldata merkleProof
     ) external override {
+        UpdateCtx memory ctx;
+        ctx.clusterId = cluster.validateHashedCluster(clusterOwner, operatorIds, SSVStorage.load());
+        ctx.blockNum = blockNum;
+        ctx.effectiveBalance = effectiveBalance;
+        ctx.merkleProof = merkleProof;
+
+        _updateClusterBalanceInternal(operatorIds, cluster, ctx);
+    }
+
+    function _updateClusterBalanceInternal(
+        uint64[] calldata operatorIds,
+        Cluster memory cluster,
+        UpdateCtx memory ctx
+    ) internal {
         StorageData storage s = SSVStorage.load();
         StorageProtocol storage sp = SSVStorageProtocol.load();
         StorageEB storage seb = SSVStorageEB.load();
 
-        bytes32 root = seb.ebRoots[blockNum];
-        if (root == bytes32(0)) {
-            revert RootNotFound();
-        }
+        bytes32 clusterId = ctx.clusterId;
 
-        bytes32 clusterId = cluster.validateHashedCluster(clusterOwner, operatorIds, s);
+        _verifyEBRoots(ctx, seb);
+        _verifyEBUpdateFrequency(clusterId, seb);
+        _verifyEBStaleness(ctx, clusterId, seb);
+        _verifyMerkleProof(ctx, seb);
+        _verifyEBMaximum(ctx, cluster);
 
-        ClusterEBSnapshot storage ebSnapshot = seb.clusterEB[clusterId];
-
-        if (
-            ebSnapshot.lastUpdateBlock != 0 && block.number < ebSnapshot.lastUpdateBlock + seb.minBlocksBetweenUpdates
-        ) {
-            revert UpdateTooFrequent();
-        }
-
-        if (ebSnapshot.lastRootBlockNum != 0 && blockNum <= ebSnapshot.lastRootBlockNum) {
-            revert StaleUpdate();
-        }
-        {
-            if (!MerkleProof.verify(merkleProof, root, keccak256(abi.encode(clusterId, effectiveBalance)))) {
-                revert InvalidProof();
-            }
-        }
-        // Check max EB allowed
-        if (effectiveBalance > uint256(cluster.validatorCount) * MAX_EB_PER_VALIDATOR) {
-            revert EBExceedsMaximum();
-        }
-
-        uint64 storedVUnits = ebSnapshot.vUnits;
-        uint64 oldVUnits = storedVUnits;
+        uint64 oldVUnits = seb.clusterEB[clusterId].vUnits;
         if (oldVUnits == 0) {
             oldVUnits = uint64(cluster.validatorCount) * VUNITS_PRECISION;
         }
 
-        uint64 newVUnits = uint64((effectiveBalance * VUNITS_PRECISION) / 32 ether);
+        uint64 newVUnits = uint64((ctx.effectiveBalance * VUNITS_PRECISION) / 32 ether);
 
-        {
-            if (cluster.active) {
-                (uint64 clusterIndex, ) = OperatorLib.updateClusterOperators(operatorIds, false, 0, s, sp);
-
-                uint64 currentNetworkFeeIndex = sp.currentNetworkFeeIndex();
-                uint128 units = oldVUnits;
-                uint128 idxNet = currentNetworkFeeIndex - cluster.networkFeeIndex;
-                uint128 idxOp = clusterIndex - cluster.index;
-
-                uint128 networkFeeUnits = (idxNet * units) / VUNITS_PRECISION;
-                uint128 operatorFeeUnits = (idxOp * units) / VUNITS_PRECISION;
-                uint64 networkFee = uint64(networkFeeUnits);
-                uint64 operatorFees = uint64(operatorFeeUnits);
-                uint64 totalFees = networkFee + operatorFees;
-
-                cluster.index = clusterIndex;
-                cluster.networkFeeIndex = currentNetworkFeeIndex;
-
-                if (cluster.balance >= totalFees.expand()) {
-                    cluster.balance -= totalFees.expand();
-                } else {
-                    cluster.balance = 0;
-                }
-
-                if (newVUnits != oldVUnits) {
-                    _updateDAOVUnits(sp, oldVUnits, newVUnits);
-                }
-            }
+        if (cluster.active) {
+            _applyClusterFeeUpdates(
+                operatorIds,
+                cluster,
+                oldVUnits,
+                newVUnits,
+                s,
+                sp
+            );
         }
 
-        // Update operatorVUnits for each operator based on the change in cluster vUnits.
+        _updateOperatorVUnits(operatorIds, seb, clusterId, newVUnits);
+
+        _updateEBSnapshot(seb, clusterId, ctx.blockNum, newVUnits);
+
+        s.clusters[clusterId] = cluster.hashClusterData();
+
+        emit ClusterBalanceUpdated(clusterId, ctx.blockNum, ctx.effectiveBalance, newVUnits);
+    }
+
+    function _verifyEBRoots(UpdateCtx memory ctx, StorageEB storage seb) internal view {
+        if (seb.ebRoots[ctx.blockNum] == bytes32(0)) revert RootNotFound();
+    }
+
+    function _verifyEBUpdateFrequency(
+        bytes32 clusterId,
+        StorageEB storage seb
+    ) internal view {
+        ClusterEBSnapshot storage ebSnapshot = seb.clusterEB[clusterId];
+        if (
+            ebSnapshot.lastUpdateBlock != 0 &&
+            block.number < ebSnapshot.lastUpdateBlock + seb.minBlocksBetweenUpdates
+        ) {
+            revert UpdateTooFrequent();
+        }
+    }
+
+    function _verifyEBStaleness(
+        UpdateCtx memory ctx,
+        bytes32 clusterId,
+        StorageEB storage seb
+    ) internal view {
+        ClusterEBSnapshot storage ebSnapshot = seb.clusterEB[clusterId];
+        if (ebSnapshot.lastRootBlockNum != 0 && ctx.blockNum <= ebSnapshot.lastRootBlockNum) {
+            revert StaleUpdate();
+        }
+    }
+
+    function _verifyMerkleProof(UpdateCtx memory ctx, StorageEB storage seb) internal view {
+        bytes32 root = seb.ebRoots[ctx.blockNum];
+
+        if (
+            !MerkleProof.verify(
+            ctx.merkleProof,
+            root,
+            keccak256(abi.encode(ctx.clusterId, ctx.effectiveBalance))
+        )
+        ) {
+            revert InvalidProof();
+        }
+    }
+
+    function _verifyEBMaximum(UpdateCtx memory ctx, Cluster memory cluster) internal pure {
+        if (ctx.effectiveBalance > uint256(cluster.validatorCount) * MAX_EB_PER_VALIDATOR) {
+            revert EBExceedsMaximum();
+        }
+    }
+
+    function _applyClusterFeeUpdates(
+        uint64[] calldata operatorIds,
+        Cluster memory cluster,
+        uint64 oldVUnits,
+        uint64 newVUnits,
+        StorageData storage s,
+        StorageProtocol storage sp
+    ) internal {
+        (uint64 clusterIndex, ) = OperatorLib.updateClusterOperators(
+            operatorIds,
+            false,
+            0,
+            s,
+            sp
+        );
+
+        uint64 currentNetworkFeeIndex = sp.currentNetworkFeeIndex();
+        uint128 units = oldVUnits;
+        uint128 idxNet = currentNetworkFeeIndex - cluster.networkFeeIndex;
+        uint128 idxOp = clusterIndex - cluster.index;
+
+        uint128 networkFeeUnits = (idxNet * units) / VUNITS_PRECISION;
+        uint128 operatorFeeUnits = (idxOp * units) / VUNITS_PRECISION;
+        uint64 networkFee = uint64(networkFeeUnits);
+        uint64 operatorFees = uint64(operatorFeeUnits);
+        uint64 totalFees = networkFee + operatorFees;
+
+        cluster.index = clusterIndex;
+        cluster.networkFeeIndex = currentNetworkFeeIndex;
+
+        if (cluster.balance >= totalFees.expand()) {
+            cluster.balance -= totalFees.expand();
+        } else {
+            cluster.balance = 0;
+        }
+
+        if (newVUnits != oldVUnits) {
+            _updateDAOVUnits(sp, oldVUnits, newVUnits);
+        }
+    }
+
+    function _updateOperatorVUnits(
+        uint64[] calldata operatorIds,
+        StorageEB storage seb,
+        bytes32 clusterId,
+        uint64 newVUnits
+    ) internal {
+        uint64 storedVUnits = seb.clusterEB[clusterId].vUnits;
+
         if (newVUnits != storedVUnits) {
             bool deltaPositive = newVUnits > storedVUnits;
             uint256 deltaClusterVUnits = deltaPositive
@@ -560,23 +639,24 @@ contract SSVClusters is ISSVClusters {
                     uint256 operatorsLength = operatorIds.length;
                     for (uint256 i; i < operatorsLength; ++i) {
                         uint64 operatorId = operatorIds[i];
-                        if (deltaPositive) {
-                            seb.operatorVUnits[operatorId] += deltaAbs;
-                        } else {
-                            seb.operatorVUnits[operatorId] -= deltaAbs;
-                        }
+                        if (deltaPositive) seb.operatorVUnits[operatorId] += deltaAbs;
+                        else seb.operatorVUnits[operatorId] -= deltaAbs;
                     }
                 }
             }
         }
+    }
 
+    function _updateEBSnapshot(
+        StorageEB storage seb,
+        bytes32 clusterId,
+        uint64 blockNum,
+        uint64 newVUnits
+    ) internal {
+        ClusterEBSnapshot storage ebSnapshot = seb.clusterEB[clusterId];
         ebSnapshot.vUnits = newVUnits;
         ebSnapshot.lastRootBlockNum = blockNum;
         ebSnapshot.lastUpdateBlock = uint64(block.number);
-
-        s.clusters[clusterId] = cluster.hashClusterData();
-
-        emit ClusterBalanceUpdated(clusterId, blockNum, effectiveBalance, newVUnits);
     }
 
     function _updateDAOVUnits(StorageProtocol storage sp, uint64 oldVUnits, uint64 newVUnits) internal {

--- a/contracts/modules/SSVClusters.sol
+++ b/contracts/modules/SSVClusters.sol
@@ -9,11 +9,15 @@ import "../libraries/CoreLib.sol";
 import "../libraries/ValidatorLib.sol";
 import {SSVStorage, StorageData} from "../libraries/SSVStorage.sol";
 import {SSVStorageProtocol, StorageProtocol} from "../libraries/SSVStorageProtocol.sol";
+import {SSVStorageEB, StorageEB, ClusterEBSnapshot, VUNITS_PRECISION, MAX_EB_PER_VALIDATOR} from "../libraries/SSVStorageEB.sol";
+import {Types64} from "../libraries/Types.sol";
+import {MerkleProof} from "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
 
 contract SSVClusters is ISSVClusters {
     using ClusterLib for Cluster;
     using OperatorLib for Operator;
     using ProtocolLib for StorageProtocol;
+    using Types64 for uint64;
 
     function registerValidator(
         bytes calldata publicKey,
@@ -34,6 +38,14 @@ contract SSVClusters is ISSVClusters {
         cluster.balance += amount;
 
         cluster.updateClusterOnRegistration(operatorIds, hashedCluster, 1, s, sp);
+
+        {
+            StorageEB storage seb = SSVStorageEB.load();
+            ClusterEBSnapshot storage ebSnapshot = seb.clusterEB[hashedCluster];
+            if (ebSnapshot.vUnits > 0) {
+                ebSnapshot.vUnits += 1;
+            }
+        }
 
         if (amount != 0) {
             CoreLib.deposit(amount);
@@ -67,6 +79,14 @@ contract SSVClusters is ISSVClusters {
         cluster.balance += amount;
 
         cluster.updateClusterOnRegistration(operatorIds, hashedCluster, uint32(validatorsLength), s, sp);
+
+        {
+            StorageEB storage seb = SSVStorageEB.load();
+            ClusterEBSnapshot storage ebSnapshot = seb.clusterEB[hashedCluster];
+            if (ebSnapshot.vUnits > 0) {
+                ebSnapshot.vUnits += uint64(validatorsLength);
+            }
+        }
 
         if (amount != 0) {
             CoreLib.deposit(amount);
@@ -112,6 +132,14 @@ contract SSVClusters is ISSVClusters {
         }
 
         --cluster.validatorCount;
+
+        {
+            StorageEB storage seb = SSVStorageEB.load();
+            ClusterEBSnapshot storage ebSnapshot = seb.clusterEB[hashedCluster];
+            if (ebSnapshot.vUnits > 0) {
+                ebSnapshot.vUnits -= 1;
+            }
+        }
 
         s.clusters[hashedCluster] = cluster.hashClusterData();
 
@@ -160,6 +188,14 @@ contract SSVClusters is ISSVClusters {
 
         cluster.validatorCount -= validatorsRemoved;
 
+        {
+            StorageEB storage seb = SSVStorageEB.load();
+            ClusterEBSnapshot storage ebSnapshot = seb.clusterEB[hashedCluster];
+            if (ebSnapshot.vUnits > 0) {
+                ebSnapshot.vUnits -= validatorsRemoved;
+            }
+        }
+
         s.clusters[hashedCluster] = cluster.hashClusterData();
 
         for (uint i; i < validatorsLength; ++i) {
@@ -183,13 +219,16 @@ contract SSVClusters is ISSVClusters {
             sp
         );
 
-        cluster.updateBalance(clusterIndex, sp.currentNetworkFeeIndex());
+        cluster.updateBalanceWithEB(hashedCluster, clusterIndex, sp.currentNetworkFeeIndex());
+        cluster.index = clusterIndex;
+        cluster.networkFeeIndex = sp.currentNetworkFeeIndex();
 
         uint256 balanceLiquidatable;
 
         if (
             clusterOwner != msg.sender &&
-            !cluster.isLiquidatable(
+            !cluster.isLiquidatableWithEB(
+                hashedCluster,
                 burnRate,
                 sp.networkFee,
                 sp.minimumBlocksBeforeLiquidation,
@@ -242,7 +281,8 @@ contract SSVClusters is ISSVClusters {
         sp.updateDAO(true, cluster.validatorCount);
 
         if (
-            cluster.isLiquidatable(
+            cluster.isLiquidatableWithEB(
+                hashedCluster,
                 burnRate,
                 sp.networkFee,
                 sp.minimumBlocksBeforeLiquidation,
@@ -303,7 +343,9 @@ contract SSVClusters is ISSVClusters {
                 }
             }
 
-            cluster.updateClusterData(clusterIndex, sp.currentNetworkFeeIndex());
+            cluster.updateBalanceWithEB(hashedCluster, clusterIndex, sp.currentNetworkFeeIndex());
+            cluster.index = clusterIndex;
+            cluster.networkFeeIndex = sp.currentNetworkFeeIndex();
         }
         if (cluster.balance < amount) revert InsufficientBalance();
 
@@ -312,7 +354,8 @@ contract SSVClusters is ISSVClusters {
         if (
             cluster.active &&
             cluster.validatorCount != 0 &&
-            cluster.isLiquidatable(
+            cluster.isLiquidatableWithEB(
+                hashedCluster,
                 burnRate,
                 sp.networkFee,
                 sp.minimumBlocksBeforeLiquidation,
@@ -355,6 +398,100 @@ contract SSVClusters is ISSVClusters {
             ) revert ISSVNetworkCore.IncorrectValidatorStateWithData(publicKeys[i]);
 
             emit ValidatorExited(msg.sender, operatorIds, publicKeys[i]);
+        }
+    }
+
+    function updateClusterBalance(
+        uint64 blockNum,
+        address clusterOwner,
+        uint64[] calldata operatorIds,
+        Cluster memory cluster,
+        uint256 effectiveBalance,
+        bytes32[] calldata merkleProof
+    ) external override {
+        StorageData storage s = SSVStorage.load();
+        StorageProtocol storage sp = SSVStorageProtocol.load();
+        StorageEB storage seb = SSVStorageEB.load();
+
+        bytes32 root = seb.ebRoots[blockNum];
+        if (root == bytes32(0)) {
+            revert RootNotFound();
+        }
+
+        bytes32 clusterId = cluster.validateHashedCluster(clusterOwner, operatorIds, s);
+
+        ClusterEBSnapshot storage ebSnapshot = seb.clusterEB[clusterId];
+
+        if (
+            ebSnapshot.lastUpdateBlock != 0 && block.number < ebSnapshot.lastUpdateBlock + seb.minBlocksBetweenUpdates
+        ) {
+            revert UpdateTooFrequent();
+        }
+
+        if (ebSnapshot.lastRootBlockNum != 0 && blockNum <= ebSnapshot.lastRootBlockNum) {
+            revert StaleUpdate();
+        }
+        {
+            if (!MerkleProof.verify(merkleProof, root, keccak256(abi.encode(clusterId, effectiveBalance)))) {
+                revert InvalidProof();
+            }
+        }
+        // Check max EB allowed
+        if (effectiveBalance > uint256(cluster.validatorCount) * MAX_EB_PER_VALIDATOR) {
+            revert EBExceedsMaximum();
+        }
+
+        uint64 oldVUnits = ebSnapshot.vUnits;
+        if (oldVUnits == 0) {
+            oldVUnits = uint64(cluster.validatorCount);
+        }
+
+        uint64 newVUnits = uint64((effectiveBalance * VUNITS_PRECISION) / 32 ether);
+        {
+            if (cluster.active) {
+                (uint64 clusterIndex, ) = OperatorLib.updateClusterOperators(operatorIds, false, 0, s, sp);
+
+                uint64 currentNetworkFeeIndex = sp.currentNetworkFeeIndex();
+                uint128 units = oldVUnits;
+                uint128 idxNet = currentNetworkFeeIndex - cluster.networkFeeIndex;
+                uint128 idxOp = clusterIndex - cluster.index;
+
+                uint128 networkFeeUnits = (idxNet * units) / VUNITS_PRECISION;
+                uint128 operatorFeeUnits = (idxOp * units) / VUNITS_PRECISION;
+                uint64 networkFee = uint64(networkFeeUnits);
+                uint64 operatorFees = uint64(operatorFeeUnits);
+                uint64 totalFees = networkFee + operatorFees;
+
+                cluster.index = clusterIndex;
+                cluster.networkFeeIndex = currentNetworkFeeIndex;
+
+                if (cluster.balance >= totalFees.expand()) {
+                    cluster.balance -= totalFees.expand();
+                } else {
+                    cluster.balance = 0;
+                }
+
+                if (newVUnits != oldVUnits) {
+                    _updateDAOVUnits(sp, oldVUnits, newVUnits);
+                }
+            }
+        }
+        ebSnapshot.vUnits = newVUnits;
+        ebSnapshot.lastRootBlockNum = blockNum;
+        ebSnapshot.lastUpdateBlock = uint64(block.number);
+
+        s.clusters[clusterId] = cluster.hashClusterData();
+
+        emit ClusterBalanceUpdated(clusterId, blockNum, effectiveBalance, newVUnits);
+    }
+
+    function _updateDAOVUnits(StorageProtocol storage sp, uint64 oldVUnits, uint64 newVUnits) internal {
+        sp.updateDAOEarnings();
+
+        if (newVUnits > oldVUnits) {
+            sp.daoTotalVUnits += newVUnits - oldVUnits;
+        } else {
+            sp.daoTotalVUnits -= oldVUnits - newVUnits;
         }
     }
 }

--- a/contracts/modules/SSVDAO.sol
+++ b/contracts/modules/SSVDAO.sol
@@ -6,6 +6,7 @@ import {Types64, Types256} from "../libraries/Types.sol";
 import "../libraries/ProtocolLib.sol";
 import "../libraries/CoreLib.sol";
 import {SSVStorageProtocol, StorageProtocol} from "../libraries/SSVStorageProtocol.sol";
+import {SSVStorageEB, StorageEB} from "../libraries/SSVStorageEB.sol";
 
 contract SSVDAO is ISSVDAO {
     using Types64 for uint64;
@@ -74,5 +75,24 @@ contract SSVDAO is ISSVDAO {
     function updateMaximumOperatorFee(uint64 maxFee) external override {
         SSVStorageProtocol.load().operatorMaxFee = maxFee;
         emit OperatorMaximumFeeUpdated(maxFee);
+    }
+
+    function commitRoot(bytes32 merkleRoot, uint64 blockNum) external override {
+        StorageEB storage seb = SSVStorageEB.load();
+
+        // Enforce monotonicity - new block must be greater than last
+        if (blockNum <= seb.latestCommittedBlock) {
+            revert StaleBlockNumber();
+        }
+
+        // Ensure block is not in the future
+        if (blockNum > block.number) {
+            revert FutureBlockNumber();
+        }
+
+        seb.ebRoots[blockNum] = merkleRoot;
+        seb.latestCommittedBlock = blockNum;
+
+        emit RootCommitted(merkleRoot, blockNum, block.timestamp);
     }
 }

--- a/contracts/modules/SSVDAO.sol
+++ b/contracts/modules/SSVDAO.sol
@@ -95,4 +95,22 @@ contract SSVDAO is ISSVDAO {
 
         emit RootCommitted(merkleRoot, blockNum, block.timestamp);
     }
+
+    function setOracleTimingConfig(
+        uint64 firstStartEpoch,
+        uint64 firstInterval,
+        uint64 secondStartEpoch,
+        uint64 secondInterval
+    ) external {
+        if (firstInterval == 0 || secondInterval == 0) {
+            revert ZeroInterval();
+        }
+
+        StorageProtocol storage sp = SSVStorageProtocol.load();
+
+        sp.oracleFirstStartEpoch = firstStartEpoch;
+        sp.oracleFirstEpochInterval = firstInterval;
+        sp.oracleSecondStartEpoch = secondStartEpoch;
+        sp.oracleSecondEpochInterval = secondInterval;
+    }
 }

--- a/contracts/modules/SSVOperators.sol
+++ b/contracts/modules/SSVOperators.sol
@@ -5,6 +5,7 @@ import {ISSVOperators} from "../interfaces/ISSVOperators.sol";
 import {Types64, Types256} from "../libraries/Types.sol";
 import {SSVStorage, StorageData} from "../libraries/SSVStorage.sol";
 import {SSVStorageProtocol, StorageProtocol} from "../libraries/SSVStorageProtocol.sol";
+import {SSVStorageEB, StorageEB} from "../libraries/SSVStorageEB.sol";
 import "../libraries/OperatorLib.sol";
 import "../libraries/CoreLib.sol";
 
@@ -64,7 +65,8 @@ contract SSVOperators is ISSVOperators {
         Operator memory operator = s.operators[operatorId];
         operator.checkOwner();
 
-        operator.updateSnapshot();
+        StorageEB storage seb = SSVStorageEB.load();
+        operator.updateSnapshot(operatorId, seb);
         uint64 currentBalance = operator.snapshot.balance;
 
         operator.snapshot.block = 0;
@@ -130,7 +132,8 @@ contract SSVOperators is ISSVOperators {
 
         if (feeChangeRequest.fee.expand() > SSVStorageProtocol.load().operatorMaxFee) revert FeeTooHigh();
 
-        operator.updateSnapshot();
+        StorageEB storage seb = SSVStorageEB.load();
+        operator.updateSnapshot(operatorId, seb);
         operator.fee = feeChangeRequest.fee;
         s.operators[operatorId] = operator;
 
@@ -160,7 +163,8 @@ contract SSVOperators is ISSVOperators {
         uint64 shrunkAmount = fee.shrink();
         if (shrunkAmount >= operator.fee) revert FeeIncreaseNotAllowed();
 
-        operator.updateSnapshot();
+        StorageEB storage seb = SSVStorageEB.load();
+        operator.updateSnapshot(operatorId, seb);
         operator.fee = shrunkAmount;
         s.operators[operatorId] = operator;
 
@@ -193,7 +197,8 @@ contract SSVOperators is ISSVOperators {
         Operator memory operator = s.operators[operatorId];
         operator.checkOwner();
 
-        operator.updateSnapshot();
+        StorageEB storage seb = SSVStorageEB.load();
+        operator.updateSnapshot(operatorId, seb);
 
         uint64 shrunkWithdrawn;
         uint64 shrunkAmount = amount.shrink();

--- a/contracts/modules/SSVViews.sol
+++ b/contracts/modules/SSVViews.sol
@@ -8,6 +8,7 @@ import "../libraries/ClusterLib.sol";
 import "../libraries/OperatorLib.sol";
 import "../libraries/CoreLib.sol";
 import "../libraries/ProtocolLib.sol";
+import {VUNITS_PRECISION} from "../libraries/SSVStorageEB.sol";
 import {SSVStorage, StorageData} from "../libraries/SSVStorage.sol";
 import {SSVStorageProtocol, StorageProtocol} from "../libraries/SSVStorageProtocol.sol";
 
@@ -176,7 +177,8 @@ contract SSVViews is ISSVViews {
         uint64[] calldata operatorIds,
         Cluster memory cluster
     ) external view override returns (bool) {
-        cluster.validateHashedCluster(clusterOwner, operatorIds, SSVStorage.load());
+        StorageData storage s = SSVStorage.load();
+        bytes32 hashedCluster = cluster.validateHashedCluster(clusterOwner, operatorIds, s);
 
         if (!cluster.active) {
             return false;
@@ -186,16 +188,20 @@ contract SSVViews is ISSVViews {
         uint64 burnRate;
         uint256 operatorsLength = operatorIds.length;
         for (uint256 i; i < operatorsLength; ++i) {
-            Operator memory operator = SSVStorage.load().operators[operatorIds[i]];
+            Operator memory operator = s.operators[operatorIds[i]];
             clusterIndex += operator.snapshot.index + (uint64(block.number) - operator.snapshot.block) * operator.fee;
             burnRate += operator.fee;
         }
 
         StorageProtocol storage sp = SSVStorageProtocol.load();
 
-        cluster.updateBalance(clusterIndex, sp.currentNetworkFeeIndex());
+        cluster.updateBalanceWithEB(hashedCluster, clusterIndex, sp.currentNetworkFeeIndex());
+        cluster.index = clusterIndex;
+        cluster.networkFeeIndex = sp.currentNetworkFeeIndex();
+
         return
-            cluster.isLiquidatable(
+            cluster.isLiquidatableWithEB(
+                hashedCluster,
                 burnRate,
                 sp.networkFee,
                 sp.minimumBlocksBeforeLiquidation,
@@ -217,18 +223,26 @@ contract SSVViews is ISSVViews {
         uint64[] calldata operatorIds,
         Cluster memory cluster
     ) external view returns (uint256) {
-        cluster.validateHashedCluster(clusterOwner, operatorIds, SSVStorage.load());
+        StorageData storage s = SSVStorage.load();
+        bytes32 hashedCluster = cluster.validateHashedCluster(clusterOwner, operatorIds, s);
 
         uint64 aggregateFee;
         uint256 operatorsLength = operatorIds.length;
         for (uint256 i; i < operatorsLength; ++i) {
-            Operator memory operator = SSVStorage.load().operators[operatorIds[i]];
+            Operator memory operator = s.operators[operatorIds[i]];
             if (operator.owner != address(0)) {
                 aggregateFee += operator.fee;
             }
         }
 
-        uint64 burnRate = (aggregateFee + SSVStorageProtocol.load().networkFee) * cluster.validatorCount;
+        StorageProtocol storage sp = SSVStorageProtocol.load();
+
+        uint64 vUnits = ClusterLib.getVUnits(hashedCluster, cluster.validatorCount);
+        uint128 totalFee = uint128(aggregateFee) + uint128(sp.networkFee);
+        uint128 units = vUnits;
+        uint128 burnRateUnits = (totalFee * units) / VUNITS_PRECISION;
+        uint64 burnRate = uint64(burnRateUnits);
+
         return burnRate.expand();
     }
 
@@ -248,14 +262,15 @@ contract SSVViews is ISSVViews {
         uint64[] calldata operatorIds,
         Cluster memory cluster
     ) external view override returns (uint256) {
-        cluster.validateHashedCluster(clusterOwner, operatorIds, SSVStorage.load());
+        StorageData storage s = SSVStorage.load();
+        bytes32 hashedCluster = cluster.validateHashedCluster(clusterOwner, operatorIds, s);
         cluster.validateClusterIsNotLiquidated();
 
         uint64 clusterIndex;
         {
             uint256 operatorsLength = operatorIds.length;
             for (uint256 i; i < operatorsLength; ++i) {
-                Operator memory operator = SSVStorage.load().operators[operatorIds[i]];
+                Operator memory operator = s.operators[operatorIds[i]];
                 clusterIndex +=
                     operator.snapshot.index +
                     (uint64(block.number) - operator.snapshot.block) *
@@ -263,7 +278,8 @@ contract SSVViews is ISSVViews {
             }
         }
 
-        cluster.updateBalance(clusterIndex, SSVStorageProtocol.load().currentNetworkFeeIndex());
+        StorageProtocol storage sp = SSVStorageProtocol.load();
+        cluster.updateBalanceWithEB(hashedCluster, clusterIndex, sp.currentNetworkFeeIndex());
 
         return cluster.balance;
     }

--- a/contracts/modules/SSVViews.sol
+++ b/contracts/modules/SSVViews.sol
@@ -289,6 +289,31 @@ contract SSVViews is ISSVViews {
     /* DAO External View Functions */
     /*******************************/
 
+    function getTargetEpoch(
+        uint64 round,
+        uint64 startEpoch,
+        uint64 epochInterval
+    ) external view returns (uint64) {
+        uint256 result = uint256(startEpoch) + uint256(round) * uint256(epochInterval);
+
+        if (result > type(uint64).max) {
+            revert EpochOverflow();
+        }
+
+        return uint64(result);
+    }
+
+    function getOracleTimingConfig(
+        uint64 referenceEpoch
+    ) external view returns (uint64 startEpoch, uint64 epochInterval) {
+        StorageProtocol storage sp = SSVStorageProtocol.load();
+
+        if (referenceEpoch >= sp.oracleSecondStartEpoch) {
+            return (sp.oracleSecondStartEpoch, sp.oracleSecondEpochInterval);
+        }
+        return (sp.oracleFirstStartEpoch, sp.oracleFirstEpochInterval);
+    }
+
     function getNetworkFee() external view override returns (uint256) {
         return SSVStorageProtocol.load().networkFee.expand();
     }

--- a/contracts/modules/SSVViews.sol
+++ b/contracts/modules/SSVViews.sol
@@ -251,9 +251,10 @@ contract SSVViews is ISSVViews {
     /***********************************/
 
     function getOperatorEarnings(uint64 id) external view override returns (uint256) {
-        Operator memory operator = SSVStorage.load().operators[id];
+        StorageData storage s = SSVStorage.load();
+        Operator memory operator = s.operators[id];
 
-        operator.updateSnapshot();
+        operator.updateSnapshot(id, SSVStorageEB.load());
         return operator.snapshot.balance.expand();
     }
 

--- a/contracts/test/SSVNetworkUpgrade.sol
+++ b/contracts/test/SSVNetworkUpgrade.sol
@@ -399,6 +399,53 @@ contract SSVNetworkUpgrade is
         );
     }
 
+    function updateClusterBalance(
+        uint64 blockNum,
+        address clusterOwner,
+        uint64[] calldata operatorIds,
+        Cluster memory cluster,
+        uint256 effectiveBalance,
+        bytes32[] calldata merkleProof
+    ) external override {
+        _delegateCall(
+            SSVStorage.load().ssvContracts[SSVModules.SSV_CLUSTERS],
+            abi.encodeWithSignature(
+                "updateClusterBalance(uint64,address,uint64[],(uint32,uint64,uint64,bool,uint256),uint256,bytes32[])",
+                blockNum,
+                clusterOwner,
+                operatorIds,
+                cluster,
+                effectiveBalance,
+                merkleProof
+            )
+        );
+    }
+
+    function commitRoot(bytes32 merkleRoot, uint64 blockNum) external override {
+        _delegateCall(
+            SSVStorage.load().ssvContracts[SSVModules.SSV_DAO],
+            abi.encodeWithSignature("commitRoot(bytes32,uint64)", merkleRoot, blockNum)
+        );
+    }
+
+    function setOracleTimingConfig(
+        uint64 firstStartEpoch,
+        uint64 firstInterval,
+        uint64 secondStartEpoch,
+        uint64 secondInterval
+    ) external onlyOwner {
+        _delegateCall(
+            SSVStorage.load().ssvContracts[SSVModules.SSV_DAO],
+            abi.encodeWithSignature(
+                "setOracleTimingConfig(uint64,uint64,uint64,uint64)",
+                firstStartEpoch,
+                firstInterval,
+                secondStartEpoch,
+                secondInterval
+            )
+        );
+    }
+
     function _delegateCall(address ssvModule, bytes memory callMessage) internal returns (bytes memory) {
         /// @custom:oz-upgrades-unsafe-allow delegatecall
         (bool success, bytes memory result) = ssvModule.delegatecall(callMessage);

--- a/contracts/test/modules/SSVOperatorsUpdate.sol
+++ b/contracts/test/modules/SSVOperatorsUpdate.sol
@@ -7,6 +7,7 @@ import "../../libraries/SSVStorage.sol";
 import "../../libraries/SSVStorageProtocol.sol";
 import "../../libraries/OperatorLib.sol";
 import "../../libraries/CoreLib.sol";
+import "../../libraries/SSVStorageEB.sol";
 
 import "@openzeppelin/contracts/utils/Counters.sol";
 
@@ -59,7 +60,8 @@ contract SSVOperatorsUpdate is ISSVOperators {
         Operator memory operator = s.operators[operatorId];
         operator.checkOwner();
 
-        operator.updateSnapshot();
+        StorageEB storage seb = SSVStorageEB.load();
+        operator.updateSnapshot(operatorId, seb);
         uint64 currentBalance = operator.snapshot.balance;
 
         operator.snapshot.block = 0;
@@ -96,7 +98,9 @@ contract SSVOperatorsUpdate is ISSVOperators {
             revert ApprovalNotWithinTimeframe();
         }
 
-        operator.updateSnapshot();
+        StorageEB storage seb = SSVStorageEB.load();
+        operator.updateSnapshot(operatorId, seb);
+        uint64 currentBalance = operator.snapshot.balance;
         operator.fee = feeChangeRequest.fee;
         s.operators[operatorId] = operator;
 
@@ -123,7 +127,9 @@ contract SSVOperatorsUpdate is ISSVOperators {
         uint64 shrunkAmount = fee.shrink();
         if (shrunkAmount >= operator.fee) revert FeeIncreaseNotAllowed();
 
-        operator.updateSnapshot();
+        StorageEB storage seb = SSVStorageEB.load();
+        operator.updateSnapshot(operatorId, seb);
+
         operator.fee = shrunkAmount;
         s.operators[operatorId] = operator;
 
@@ -156,7 +162,8 @@ contract SSVOperatorsUpdate is ISSVOperators {
         Operator memory operator = s.operators[operatorId];
         operator.checkOwner();
 
-        operator.updateSnapshot();
+        StorageEB storage seb = SSVStorageEB.load();
+        operator.updateSnapshot(operatorId, seb);
 
         uint64 shrunkWithdrawn;
         uint64 shrunkAmount = amount.shrink();


### PR DESCRIPTION
This PR introduces support for the Effective Balance (EB) oracle system, which updates the SSV Network's accounting model from validator-count-based fees to EB-weighted fees (vUnits). This allows operator and network fees to scale proportionally with actual staked ETH rather than treating all validators equally.

Specs: https://hackmd.io/@mtabasco/EB-submission-contracts

**Backwards Compatibility**
- Before oracles activate, all EB storage is zero
- `getVUnits` falls back to `validatorCount` * `VUNITS_PRECISION`
- Operator snapshots fall back when `operatorVUnits` == 0
- No migration required; EB accounting activates per-cluster on first `updateClusterBalance`

**Known Issues**
Stack-too-deep in `updateClusterBalance`