### PR TITLE
feat: add oracle commit status view function

### DIFF
--- a/contracts/SSVNetworkViews.sol
+++ b/contracts/SSVNetworkViews.sol
@@ -270,6 +270,10 @@ contract SSVNetworkViews is UUPSUpgradeable, Ownable2StepUpgradeable, ISSVViews 
         return ssvNetwork.getQuorumBps();
     }
 
+    function getCommittedRoot(uint64 blockNum) external view override returns (bytes32) {
+        return ssvNetwork.getCommittedRoot(blockNum);
+    }
+
     function getVersion() external view override returns (string memory) {
         return ssvNetwork.getVersion();
     }

--- a/contracts/interfaces/ISSVViews.sol
+++ b/contracts/interfaces/ISSVViews.sol
@@ -261,6 +261,11 @@ interface ISSVViews is ISSVNetworkCore {
     function getUserDelegation(address user) external view returns (uint32[4] memory oracleIds, uint256[4] memory amounts);
     function getQuorumBps() external view returns (uint16);
 
+    /// @notice Gets the committed merkle root for a specific block
+    /// @param blockNum The block number to query
+    /// @return merkleRoot The committed merkle root, or bytes32(0) if not committed
+    function getCommittedRoot(uint64 blockNum) external view returns (bytes32 merkleRoot);
+
     /// @notice Gets the version of the contract
     /// @return The version of the contract
     function getVersion() external view returns (string memory);

--- a/contracts/modules/SSVViews.sol
+++ b/contracts/modules/SSVViews.sol
@@ -12,6 +12,7 @@ import "../libraries/ProtocolLib.sol";
 import {SSVStorage, StorageData} from "../libraries/SSVStorage.sol";
 import {SSVStorageProtocol, StorageProtocol} from "../libraries/SSVStorageProtocol.sol";
 import {SSVStorageStaking, StorageStaking, UnstakeRequest, Delegation} from "../libraries/SSVStorageStaking.sol";
+import {SSVStorageEB} from "../libraries/SSVStorageEB.sol";
 
 contract SSVViews is ISSVViews {
     using Types64 for uint64;
@@ -532,6 +533,10 @@ contract SSVViews is ISSVViews {
 
     function getQuorumBps() external view override returns (uint16) {
         return SSVStorageStaking.load().quorumBps;
+    }
+
+    function getCommittedRoot(uint64 blockNum) external view override returns (bytes32) {
+        return SSVStorageEB.load().ebRoots[blockNum];
     }
 
     function _previewAccEthPerShare(StorageStaking storage s) internal view returns (uint256) {


### PR DESCRIPTION
## Summary

Add `getCommittedRoot(uint64 blockNum)` view function to allow oracles to check if a merkle root has been committed for a specific block.

## Motivation

When 3 of 4 oracles reach quorum, the 4th oracle currently has no way to know and wastes gas on a redundant `commitRoot()` call. This view function allows oracles to check before submitting.

## Changes

- `ISSVViews.sol` - Add interface definition with NatSpec
- `SSVViews.sol` - Add implementation returning `SSVStorageEB.load().ebRoots[blockNum]`
- `SSVNetworkViews.sol` - Add proxy delegation

## Usage

```solidity
// Before calling commitRoot(merkleRoot, blockNum):
if (views.getCommittedRoot(targetBlock) != bytes32(0)) {
    return; // Already committed, skip
}

Returns bytes32(0) if no root committed for that block.
```