### PR TITLE
fix: prevent effective balance precision loss in roundtrip conversion

### DIFF
--- a/contracts/libraries/SSVStorageEB.sol
+++ b/contracts/libraries/SSVStorageEB.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.24;
 
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+
 uint32 constant VUNITS_PRECISION = 10_000;
 uint256 constant MAX_EB_PER_VALIDATOR = 2048 ether;
 uint256 constant DEFAULT_EB_PER_VALIDATOR = 32 ether;
@@ -28,6 +30,23 @@ struct StorageEB {
     mapping(bytes32 => uint256) rootCommitments;
     /// @notice Tracks if an oracle ID has voted for a specific commitment key
     mapping(bytes32 => mapping(uint32 => bool)) hasVoted;
+}
+
+/// @notice Convert effective balance to vUnits using ceiling division (write path)
+/// @param effectiveBalance The effective balance in ETH
+/// @return vUnits value with VUNITS_PRECISION scaling
+function ebToVUnits(uint32 effectiveBalance) pure returns (uint64) {
+    return uint64(Math.ceilDiv(
+        uint256(effectiveBalance) * VUNITS_PRECISION,
+        DEFAULT_EB_PER_VALIDATOR / 1 ether
+    ));
+}
+
+/// @notice Convert vUnits to effective balance using floor division (read path)
+/// @param vUnits The vUnits value with VUNITS_PRECISION scaling
+/// @return effectiveBalance in ETH
+function vUnitsToEB(uint64 vUnits) pure returns (uint32) {
+    return uint32((uint256(vUnits) * (DEFAULT_EB_PER_VALIDATOR / 1 ether)) / VUNITS_PRECISION);
 }
 
 library SSVStorageEB {

--- a/contracts/modules/SSVClusters.sol
+++ b/contracts/modules/SSVClusters.sol
@@ -14,11 +14,12 @@ import {
     StorageEB,
     ClusterEBSnapshot,
     VUNITS_PRECISION,
-    MAX_EB_PER_VALIDATOR
+    MAX_EB_PER_VALIDATOR,
+    ebToVUnits,
+    vUnitsToEB
 } from "../libraries/SSVStorageEB.sol";
 import {Types64} from "../libraries/Types.sol";
 import {MerkleProof} from "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
-import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract SSVClusters is ISSVClusters {
     using ClusterLib for Cluster;
@@ -343,7 +344,7 @@ contract SSVClusters is ISSVClusters {
         if (vUnits == 0) {
             vUnits = uint64(cluster.validatorCount) * VUNITS_PRECISION;
         }
-        uint32 effectiveBalance = uint32((uint256(vUnits) * (DEFAULT_EB_PER_VALIDATOR / 1 ether)) / VUNITS_PRECISION);
+        uint32 effectiveBalance = vUnitsToEB(vUnits);
 
         emit ClusterMigratedToETH(msg.sender, operatorIds, msg.value, ssvBalance, effectiveBalance, cluster);
     }
@@ -515,10 +516,7 @@ contract SSVClusters is ISSVClusters {
             oldVUnits = uint64(cluster.validatorCount) * VUNITS_PRECISION;
         }
 
-        uint64 newVUnits = uint64(Math.ceilDiv(
-            ctx.effectiveBalance * VUNITS_PRECISION,
-            DEFAULT_EB_PER_VALIDATOR / 1 ether
-        ));
+        uint64 newVUnits = ebToVUnits(ctx.effectiveBalance);
 
         if (cluster.active) {
             _applyClusterFeeUpdates(operatorIds, cluster, oldVUnits, newVUnits, ctx.version, s, sp);

--- a/contracts/modules/SSVClusters.sol
+++ b/contracts/modules/SSVClusters.sol
@@ -342,7 +342,7 @@ contract SSVClusters is ISSVClusters {
         if (vUnits == 0) {
             vUnits = uint64(cluster.validatorCount) * VUNITS_PRECISION;
         }
-        uint32 effectiveBalance = uint32((uint256(vUnits) * 32 ether) / VUNITS_PRECISION);
+        uint32 effectiveBalance = uint32((uint256(vUnits) * (DEFAULT_EB_PER_VALIDATOR / 1 ether)) / VUNITS_PRECISION);
 
         emit ClusterMigratedToETH(msg.sender, operatorIds, msg.value, ssvBalance, effectiveBalance, cluster);
     }
@@ -514,7 +514,11 @@ contract SSVClusters is ISSVClusters {
             oldVUnits = uint64(cluster.validatorCount) * VUNITS_PRECISION;
         }
 
-        uint64 newVUnits = uint64((ctx.effectiveBalance * VUNITS_PRECISION) / (DEFAULT_EB_PER_VALIDATOR / 1 ether));
+        // Ceiling division to prevent precision loss on roundtrip read
+        uint64 newVUnits = uint64(
+            (ctx.effectiveBalance * VUNITS_PRECISION + (DEFAULT_EB_PER_VALIDATOR / 1 ether) - 1) /
+                (DEFAULT_EB_PER_VALIDATOR / 1 ether)
+        );
 
         if (cluster.active) {
             _applyClusterFeeUpdates(operatorIds, cluster, oldVUnits, newVUnits, ctx.version, s, sp);

--- a/contracts/modules/SSVClusters.sol
+++ b/contracts/modules/SSVClusters.sol
@@ -18,6 +18,7 @@ import {
 } from "../libraries/SSVStorageEB.sol";
 import {Types64} from "../libraries/Types.sol";
 import {MerkleProof} from "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 contract SSVClusters is ISSVClusters {
     using ClusterLib for Cluster;
@@ -514,11 +515,10 @@ contract SSVClusters is ISSVClusters {
             oldVUnits = uint64(cluster.validatorCount) * VUNITS_PRECISION;
         }
 
-        // Ceiling division to prevent precision loss on roundtrip read
-        uint64 newVUnits = uint64(
-            (ctx.effectiveBalance * VUNITS_PRECISION + (DEFAULT_EB_PER_VALIDATOR / 1 ether) - 1) /
-                (DEFAULT_EB_PER_VALIDATOR / 1 ether)
-        );
+        uint64 newVUnits = uint64(Math.ceilDiv(
+            ctx.effectiveBalance * VUNITS_PRECISION,
+            DEFAULT_EB_PER_VALIDATOR / 1 ether
+        ));
 
         if (cluster.active) {
             _applyClusterFeeUpdates(operatorIds, cluster, oldVUnits, newVUnits, ctx.version, s, sp);

--- a/contracts/modules/SSVViews.sol
+++ b/contracts/modules/SSVViews.sol
@@ -12,7 +12,7 @@ import "../libraries/ProtocolLib.sol";
 import {SSVStorage, StorageData} from "../libraries/SSVStorage.sol";
 import {SSVStorageProtocol, StorageProtocol} from "../libraries/SSVStorageProtocol.sol";
 import {SSVStorageStaking, StorageStaking, UnstakeRequest, Delegation} from "../libraries/SSVStorageStaking.sol";
-import {SSVStorageEB} from "../libraries/SSVStorageEB.sol";
+import {SSVStorageEB, vUnitsToEB} from "../libraries/SSVStorageEB.sol";
 
 contract SSVViews is ISSVViews {
     using Types64 for uint64;
@@ -411,9 +411,7 @@ contract SSVViews is ISSVViews {
             vUnits = cluster.validatorCount * VUNITS_PRECISION;
         }
 
-        return uint32(
-            (uint256(vUnits) * (DEFAULT_EB_PER_VALIDATOR / 1 ether)) / VUNITS_PRECISION
-        );
+        return vUnitsToEB(vUnits);
     }
 
     function getClusterVersion(address clusterOwner, uint64[] calldata operatorIds) external view override returns (uint8) {

--- a/contracts/test/mocks/EffectiveBalanceTest.sol
+++ b/contracts/test/mocks/EffectiveBalanceTest.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.24;
+
+import {VUNITS_PRECISION, DEFAULT_EB_PER_VALIDATOR} from "../../libraries/SSVStorageEB.sol";
+
+/// @notice Test contract to verify effective balance roundtrip conversion
+contract EffectiveBalanceTest {
+    /// @notice Convert effective balance to vUnits using ceiling division (write path)
+    function effectiveBalanceToVUnits(uint32 effectiveBalance) public pure returns (uint64) {
+        return uint64(
+            (effectiveBalance * VUNITS_PRECISION + (DEFAULT_EB_PER_VALIDATOR / 1 ether) - 1) /
+                (DEFAULT_EB_PER_VALIDATOR / 1 ether)
+        );
+    }
+
+    /// @notice Convert vUnits back to effective balance (read path)
+    function vUnitsToEffectiveBalance(uint64 vUnits) public pure returns (uint32) {
+        return uint32((uint256(vUnits) * (DEFAULT_EB_PER_VALIDATOR / 1 ether)) / VUNITS_PRECISION);
+    }
+
+    /// @notice Test roundtrip conversion - should return original value or higher
+    function testRoundtrip(uint32 effectiveBalance) public pure returns (uint32 result, bool success) {
+        uint64 vUnits = effectiveBalanceToVUnits(effectiveBalance);
+        result = vUnitsToEffectiveBalance(vUnits);
+        // After fix: result should equal effectiveBalance (no precision loss)
+        success = (result >= effectiveBalance);
+    }
+
+    /// @notice Old conversion (floor division) for comparison - DO NOT USE
+    function effectiveBalanceToVUnitsOld(uint32 effectiveBalance) public pure returns (uint64) {
+        return uint64((effectiveBalance * VUNITS_PRECISION) / (DEFAULT_EB_PER_VALIDATOR / 1 ether));
+    }
+
+    /// @notice Test old roundtrip to demonstrate the bug
+    function testRoundtripOld(uint32 effectiveBalance) public pure returns (uint32 result, bool success) {
+        uint64 vUnits = effectiveBalanceToVUnitsOld(effectiveBalance);
+        result = vUnitsToEffectiveBalance(vUnits);
+        success = (result >= effectiveBalance);
+    }
+}

--- a/contracts/test/mocks/EffectiveBalanceTest.sol
+++ b/contracts/test/mocks/EffectiveBalanceTest.sol
@@ -1,40 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.24;
 
-import {VUNITS_PRECISION, DEFAULT_EB_PER_VALIDATOR} from "../../libraries/SSVStorageEB.sol";
+import {ebToVUnits, vUnitsToEB} from "../../libraries/SSVStorageEB.sol";
 
-/// @notice Test contract to verify effective balance roundtrip conversion
 contract EffectiveBalanceTest {
-    /// @notice Convert effective balance to vUnits using ceiling division (write path)
-    function effectiveBalanceToVUnits(uint32 effectiveBalance) public pure returns (uint64) {
-        return uint64(
-            (effectiveBalance * VUNITS_PRECISION + (DEFAULT_EB_PER_VALIDATOR / 1 ether) - 1) /
-                (DEFAULT_EB_PER_VALIDATOR / 1 ether)
-        );
-    }
-
-    /// @notice Convert vUnits back to effective balance (read path)
-    function vUnitsToEffectiveBalance(uint64 vUnits) public pure returns (uint32) {
-        return uint32((uint256(vUnits) * (DEFAULT_EB_PER_VALIDATOR / 1 ether)) / VUNITS_PRECISION);
-    }
-
-    /// @notice Test roundtrip conversion - should return original value or higher
-    function testRoundtrip(uint32 effectiveBalance) public pure returns (uint32 result, bool success) {
-        uint64 vUnits = effectiveBalanceToVUnits(effectiveBalance);
-        result = vUnitsToEffectiveBalance(vUnits);
-        // After fix: result should equal effectiveBalance (no precision loss)
-        success = (result >= effectiveBalance);
-    }
-
-    /// @notice Old conversion (floor division) for comparison - DO NOT USE
-    function effectiveBalanceToVUnitsOld(uint32 effectiveBalance) public pure returns (uint64) {
-        return uint64((effectiveBalance * VUNITS_PRECISION) / (DEFAULT_EB_PER_VALIDATOR / 1 ether));
-    }
-
-    /// @notice Test old roundtrip to demonstrate the bug
-    function testRoundtripOld(uint32 effectiveBalance) public pure returns (uint32 result, bool success) {
-        uint64 vUnits = effectiveBalanceToVUnitsOld(effectiveBalance);
-        result = vUnitsToEffectiveBalance(vUnits);
-        success = (result >= effectiveBalance);
+    function testRoundtrip(uint32 effectiveBalance) public pure returns (uint64 vUnits, uint32 result, bool success) {
+        vUnits = ebToVUnits(effectiveBalance);
+        result = vUnitsToEB(vUnits);
+        success = (result == effectiveBalance);
     }
 }

--- a/test/sanity/effective-balance.ts
+++ b/test/sanity/effective-balance.ts
@@ -11,74 +11,28 @@ describe('Effective Balance Roundtrip Tests', () => {
     await testContract.waitForDeployment();
   });
 
-  describe('Ceiling division fix', () => {
-    // Test cases: values that would lose precision with floor division
+  describe('Roundtrip conversion', () => {
     const testCases = [
-      { effectiveBalance: 515, description: '515 ETH (loses 1 ETH with old formula)' },
-      { effectiveBalance: 32, description: '32 ETH (1 validator, exact)' },
-      { effectiveBalance: 64, description: '64 ETH (2 validators, exact)' },
-      { effectiveBalance: 33, description: '33 ETH (1 validator + 1)' },
-      { effectiveBalance: 63, description: '63 ETH (2 validators - 1)' },
-      { effectiveBalance: 100, description: '100 ETH' },
-      { effectiveBalance: 1000, description: '1000 ETH' },
-      { effectiveBalance: 2048, description: '2048 ETH (max per validator)' },
-      { effectiveBalance: 0, description: '0 ETH (edge case)' },
-      { effectiveBalance: 1, description: '1 ETH (minimum)' },
-      { effectiveBalance: 31, description: '31 ETH (below 1 validator)' },
+      { effectiveBalance: 0, expectedVUnits: 0n, description: '0 ETH (edge case)' },
+      { effectiveBalance: 1, expectedVUnits: 313n, description: '1 ETH (minimum)' },
+      { effectiveBalance: 31, expectedVUnits: 9688n, description: '31 ETH (below 1 validator)' },
+      { effectiveBalance: 32, expectedVUnits: 10000n, description: '32 ETH (1 validator, exact)' },
+      { effectiveBalance: 33, expectedVUnits: 10313n, description: '33 ETH (ceiling)' },
+      { effectiveBalance: 63, expectedVUnits: 19688n, description: '63 ETH' },
+      { effectiveBalance: 64, expectedVUnits: 20000n, description: '64 ETH (2 validators, exact)' },
+      { effectiveBalance: 100, expectedVUnits: 31250n, description: '100 ETH' },
+      { effectiveBalance: 515, expectedVUnits: 160938n, description: '515 ETH (ceiling)' },
+      { effectiveBalance: 1000, expectedVUnits: 312500n, description: '1000 ETH' },
+      { effectiveBalance: 2048, expectedVUnits: 640000n, description: '2048 ETH (max per validator)' },
     ];
 
-    for (const { effectiveBalance, description } of testCases) {
-      it(`Roundtrip preserves value: ${description}`, async () => {
-        const [result, success] = await testContract.testRoundtrip(effectiveBalance);
+    for (const { effectiveBalance, expectedVUnits, description } of testCases) {
+      it(`${description}`, async () => {
+        const [vUnits, result, success] = await testContract.testRoundtrip(effectiveBalance);
         expect(success).to.be.true;
-        expect(Number(result)).to.equal(effectiveBalance);
+        expect(result).to.equal(effectiveBalance);
+        expect(vUnits).to.equal(expectedVUnits);
       });
     }
-  });
-
-  describe('Old formula (floor division) demonstrates precision loss', () => {
-    it('515 ETH loses 1 ETH with old formula', async () => {
-      const [result, success] = await testContract.testRoundtripOld(515);
-      expect(success).to.be.false; // Old formula fails
-      expect(Number(result)).to.equal(514); // Lost 1 ETH
-    });
-
-    it('33 ETH loses 1 ETH with old formula', async () => {
-      const [result, success] = await testContract.testRoundtripOld(33);
-      expect(success).to.be.false;
-      expect(Number(result)).to.equal(32);
-    });
-  });
-
-  describe('Conversion functions', () => {
-    it('effectiveBalanceToVUnits: 32 ETH = 10000 vUnits', async () => {
-      const vUnits = await testContract.effectiveBalanceToVUnits(32);
-      expect(vUnits).to.equal(10000n);
-    });
-
-    it('effectiveBalanceToVUnits: 64 ETH = 20000 vUnits', async () => {
-      const vUnits = await testContract.effectiveBalanceToVUnits(64);
-      expect(vUnits).to.equal(20000n);
-    });
-
-    it('vUnitsToEffectiveBalance: 10000 vUnits = 32 ETH', async () => {
-      const eb = await testContract.vUnitsToEffectiveBalance(10000);
-      expect(Number(eb)).to.equal(32);
-    });
-
-    it('vUnitsToEffectiveBalance: 20000 vUnits = 64 ETH', async () => {
-      const eb = await testContract.vUnitsToEffectiveBalance(20000);
-      expect(Number(eb)).to.equal(64);
-    });
-
-    it('Ceiling division rounds up correctly for 515 ETH', async () => {
-      // With ceiling: (515 * 10000 + 31) / 32 = 160938
-      const vUnits = await testContract.effectiveBalanceToVUnits(515);
-      expect(vUnits).to.equal(160938n);
-
-      // Read back: (160938 * 32) / 10000 = 515
-      const eb = await testContract.vUnitsToEffectiveBalance(vUnits);
-      expect(Number(eb)).to.equal(515);
-    });
   });
 });

--- a/test/sanity/effective-balance.ts
+++ b/test/sanity/effective-balance.ts
@@ -1,10 +1,11 @@
-import { ethers } from 'hardhat';
+import hre from 'hardhat';
 import { expect } from 'chai';
 
 describe('Effective Balance Roundtrip Tests', () => {
   let testContract: any;
 
   before(async () => {
+    const { ethers } = await hre.network.connect();
     const factory = await ethers.getContractFactory('EffectiveBalanceTest');
     testContract = await factory.deploy();
     await testContract.waitForDeployment();

--- a/test/sanity/effective-balance.ts
+++ b/test/sanity/effective-balance.ts
@@ -1,0 +1,83 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+
+describe('Effective Balance Roundtrip Tests', () => {
+  let testContract: any;
+
+  before(async () => {
+    const factory = await ethers.getContractFactory('EffectiveBalanceTest');
+    testContract = await factory.deploy();
+    await testContract.waitForDeployment();
+  });
+
+  describe('Ceiling division fix', () => {
+    // Test cases: values that would lose precision with floor division
+    const testCases = [
+      { effectiveBalance: 515, description: '515 ETH (loses 1 ETH with old formula)' },
+      { effectiveBalance: 32, description: '32 ETH (1 validator, exact)' },
+      { effectiveBalance: 64, description: '64 ETH (2 validators, exact)' },
+      { effectiveBalance: 33, description: '33 ETH (1 validator + 1)' },
+      { effectiveBalance: 63, description: '63 ETH (2 validators - 1)' },
+      { effectiveBalance: 100, description: '100 ETH' },
+      { effectiveBalance: 1000, description: '1000 ETH' },
+      { effectiveBalance: 2048, description: '2048 ETH (max per validator)' },
+      { effectiveBalance: 0, description: '0 ETH (edge case)' },
+      { effectiveBalance: 1, description: '1 ETH (minimum)' },
+      { effectiveBalance: 31, description: '31 ETH (below 1 validator)' },
+    ];
+
+    for (const { effectiveBalance, description } of testCases) {
+      it(`Roundtrip preserves value: ${description}`, async () => {
+        const [result, success] = await testContract.testRoundtrip(effectiveBalance);
+        expect(success).to.be.true;
+        expect(Number(result)).to.equal(effectiveBalance);
+      });
+    }
+  });
+
+  describe('Old formula (floor division) demonstrates precision loss', () => {
+    it('515 ETH loses 1 ETH with old formula', async () => {
+      const [result, success] = await testContract.testRoundtripOld(515);
+      expect(success).to.be.false; // Old formula fails
+      expect(Number(result)).to.equal(514); // Lost 1 ETH
+    });
+
+    it('33 ETH loses 1 ETH with old formula', async () => {
+      const [result, success] = await testContract.testRoundtripOld(33);
+      expect(success).to.be.false;
+      expect(Number(result)).to.equal(32);
+    });
+  });
+
+  describe('Conversion functions', () => {
+    it('effectiveBalanceToVUnits: 32 ETH = 10000 vUnits', async () => {
+      const vUnits = await testContract.effectiveBalanceToVUnits(32);
+      expect(vUnits).to.equal(10000n);
+    });
+
+    it('effectiveBalanceToVUnits: 64 ETH = 20000 vUnits', async () => {
+      const vUnits = await testContract.effectiveBalanceToVUnits(64);
+      expect(vUnits).to.equal(20000n);
+    });
+
+    it('vUnitsToEffectiveBalance: 10000 vUnits = 32 ETH', async () => {
+      const eb = await testContract.vUnitsToEffectiveBalance(10000);
+      expect(Number(eb)).to.equal(32);
+    });
+
+    it('vUnitsToEffectiveBalance: 20000 vUnits = 64 ETH', async () => {
+      const eb = await testContract.vUnitsToEffectiveBalance(20000);
+      expect(Number(eb)).to.equal(64);
+    });
+
+    it('Ceiling division rounds up correctly for 515 ETH', async () => {
+      // With ceiling: (515 * 10000 + 31) / 32 = 160938
+      const vUnits = await testContract.effectiveBalanceToVUnits(515);
+      expect(vUnits).to.equal(160938n);
+
+      // Read back: (160938 * 32) / 10000 = 515
+      const eb = await testContract.vUnitsToEffectiveBalance(vUnits);
+      expect(Number(eb)).to.equal(515);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fix precision loss when converting between `effectiveBalance` and `vUnits`.

**Problem:** `515 ETH → 160937 vUnits → 514 ETH` (lost 1 ETH due to floor division)

**Fix:** Use ceiling division on write path via `Math.ceilDiv`

**Result:** `515 ETH → 160938 vUnits → 515 ETH` ✓

## Changes

- Add `ebToVUnits()` and `vUnitsToEB()` functions to `SSVStorageEB.sol`
- Use these functions in `SSVClusters.sol` and `SSVViews.sol`
- Add unit tests for roundtrip conversion