### PR TITLE
fix: correct typo _cluserData to _clusterData in mock contracts

### DIFF
--- a/contracts/test/mocks/AttackerWhitelistingContract.sol
+++ b/contracts/test/mocks/AttackerWhitelistingContract.sol
@@ -18,8 +18,8 @@ contract AttackerContract {
         uint64[] memory _operatorIds,
         bytes calldata _sharesData,
         uint256 _amount,
-        ISSVNetworkCore.Cluster memory _cluserData
+        ISSVNetworkCore.Cluster memory _clusterData
     ) external {
-        ISSVClusters(ssvContract).registerValidator(_publicKey, _operatorIds, _sharesData, _amount, _cluserData);
+        ISSVClusters(ssvContract).registerValidator(_publicKey, _operatorIds, _sharesData, _amount, _clusterData);
     }
 }

--- a/contracts/test/mocks/FakeWhitelistingContract.sol
+++ b/contracts/test/mocks/FakeWhitelistingContract.sol
@@ -32,13 +32,13 @@ contract FakeWhitelistingContract is ERC165 {
         uint64[] memory _operatorIds,
         bytes calldata _sharesData,
         uint256 _amount,
-        Cluster memory _cluserData
+        Cluster memory _clusterData
     ) external {
         publicKey = _publicKey;
         operatorIds = _operatorIds;
         sharesData = _sharesData;
         amount = _amount;
-        clusterData = _cluserData;
+        clusterData = _clusterData;
     }
 
     function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {

--- a/contracts/test/mocks/GenericWhitelistContract.sol
+++ b/contracts/test/mocks/GenericWhitelistContract.sol
@@ -19,9 +19,9 @@ contract GenericWhitelistContract {
         uint64[] memory _operatorIds,
         bytes calldata _sharesData,
         uint256 _amount,
-        ISSVNetworkCore.Cluster memory _cluserData
+        ISSVNetworkCore.Cluster memory _clusterData
     ) external {
         ssvToken.approve(address(ssvContract), _amount);
-        ssvContract.registerValidator(_publicKey, _operatorIds, _sharesData, _amount, _cluserData);
+        ssvContract.registerValidator(_publicKey, _operatorIds, _sharesData, _amount, _clusterData);
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes a typo in the mock contract files where `_cluserData` was incorrectly spelled instead of `_clusterData`.

## Changes
- `contracts/test/mocks/GenericWhitelistContract.sol`: Fixed parameter name and usage
- `contracts/test/mocks/AttackerWhitelistingContract.sol`: Fixed parameter name and usage
- `contracts/test/mocks/FakeWhitelistingContract.sol`: Fixed parameter name and assignment

## Type of Change
- [x] Bug fix (typo correction)