### PR TITLE
fix: update cluster operators refactor

### DIFF
--- a/contracts/libraries/OperatorLib.sol
+++ b/contracts/libraries/OperatorLib.sol
@@ -202,34 +202,67 @@ library OperatorLib {
         bool increaseValidatorCount,
         uint32 deltaValidatorCount,
         StorageData storage s,
-        StorageProtocol storage sp,
-        bool isClusterLiquidated
+        StorageProtocol storage sp
     ) internal returns (uint64 cumulativeIndex, uint64 cumulativeFee) {
         uint256 operatorsLength = operatorIds.length;
-
         for (uint256 i; i < operatorsLength; ++i) {
             uint64 operatorId = operatorIds[i];
-
             ISSVNetworkCore.Operator storage operator = s.operators[operatorId];
 
-            if (operator.ethSnapshot.block == 0) {
-                updateSnapshotStSSV(operator, operatorId);
-                if (increaseValidatorCount && !isClusterLiquidated) {
-                    operator.validatorCount -= deltaValidatorCount;
-                }
-                ensureETHDefaults(operator);
-            }
-
+            // only update active operators (block != 0)
+            // removed operators have block == 0 and contribute their preserved index
             if (operator.ethSnapshot.block != 0) {
                 updateSnapshotSt(operator, operatorId);
-                if (!increaseValidatorCount) {
+
+                if (increaseValidatorCount) {
+                    if ((operator.ethValidatorCount += deltaValidatorCount) > sp.validatorsPerOperatorLimit) {
+                        revert ISSVNetworkCore.ExceedValidatorLimitWithData(operatorId);
+                    }
+                } else {
                     operator.ethValidatorCount -= deltaValidatorCount;
-                } else if ((operator.ethValidatorCount += deltaValidatorCount) > sp.validatorsPerOperatorLimit) {
-                    revert ISSVNetworkCore.ExceedValidatorLimitWithData(operatorId);
                 }
 
                 cumulativeFee += operator.ethFee;
             }
+            cumulativeIndex += operator.ethSnapshot.index;
+        }
+    }
+
+    function updateClusterOperatorsMigration(
+        uint64[] memory operatorIds,
+        uint32 validatorCount,
+        StorageData storage s,
+        StorageProtocol storage sp,
+        bool isClusterLiquidated
+    ) internal returns (uint64 cumulativeIndex, uint64 cumulativeFee) {
+        uint256 operatorsLength = operatorIds.length;
+        for (uint256 i; i < operatorsLength; ++i) {
+            uint64 operatorId = operatorIds[i];
+            ISSVNetworkCore.Operator storage operator = s.operators[operatorId];
+
+            if (operator.ethSnapshot.block == 0) {
+                // first-time ETH usage or migration
+                updateSnapshotStSSV(operator, operatorId);
+
+                if (!isClusterLiquidated) {
+                    operator.validatorCount -= validatorCount;
+                }
+
+                ensureETHDefaults(operator);
+
+                // initialize ETH validator count
+                if ((operator.ethValidatorCount += validatorCount) > sp.validatorsPerOperatorLimit) {
+                    revert ISSVNetworkCore.ExceedValidatorLimitWithData(operatorId);
+                }
+            } else {
+                // already ETH operator
+                updateSnapshotSt(operator, operatorId);
+                if ((operator.ethValidatorCount += validatorCount) > sp.validatorsPerOperatorLimit) {
+                    revert ISSVNetworkCore.ExceedValidatorLimitWithData(operatorId);
+                }
+            }
+
+            cumulativeFee += operator.ethFee;
             cumulativeIndex += operator.ethSnapshot.index;
         }
     }

--- a/contracts/modules/SSVClusters.sol
+++ b/contracts/modules/SSVClusters.sol
@@ -85,8 +85,7 @@ contract SSVClusters is ISSVClusters, SSVReentrancyGuard {
             false,
             cluster.validatorCount,
             s,
-            sp,
-            false
+            sp
         );
 
         _updateClusterDataWithEB(cluster, hashedCluster, clusterIndex, sp.currentNetworkFeeIndex());
@@ -164,8 +163,7 @@ contract SSVClusters is ISSVClusters, SSVReentrancyGuard {
             true,
             cluster.validatorCount,
             s,
-            sp,
-            false
+            sp
         );
 
         cluster.balance += msg.value;
@@ -302,9 +300,8 @@ contract SSVClusters is ISSVClusters, SSVReentrancyGuard {
         uint256 ssvBalance = cluster.balance;
 
         // compute cluster data using ETH fields
-        (uint64 clusterIndex, uint64 burnRate) = OperatorLib.updateClusterOperators(
+        (uint64 clusterIndex, uint64 burnRate) = OperatorLib.updateClusterOperatorsMigration(
             operatorIds,
-            true,
             cluster.validatorCount,
             s,
             sp,
@@ -455,14 +452,13 @@ contract SSVClusters is ISSVClusters, SSVReentrancyGuard {
                 false,
                 validatorsRemoved,
                 s,
-                sp,
-                false
+                sp
             );
 
-            cluster.updateClusterData(clusterIndex, sp.currentNetworkFeeIndex());
+        cluster.updateClusterData(clusterIndex, sp.currentNetworkFeeIndex());
 
-            sp.updateDAO(false, validatorsRemoved);
-        }
+        sp.updateDAO(false, validatorsRemoved);
+    }
 
         cluster.validatorCount -= validatorsRemoved;
 
@@ -610,7 +606,7 @@ contract SSVClusters is ISSVClusters, SSVReentrancyGuard {
 
         if (version == CoreLib.VERSION_ETH) {
             // ETH path: use ethSnapshot, ethFee, ethNetworkFeeIndex
-            (clusterIndex, ) = OperatorLib.updateClusterOperators(operatorIds, false, 0, s, sp, false);
+            (clusterIndex, ) = OperatorLib.updateClusterOperators(operatorIds, false, 0, s, sp);
             currentNetworkFeeIndex = sp.currentNetworkFeeIndex(); // ETH network fee index
         } else {
             // SSV path: use snapshot, fee, networkFeeIndex

--- a/contracts/modules/SSVOperators.sol
+++ b/contracts/modules/SSVOperators.sol
@@ -71,8 +71,7 @@ contract SSVOperators is ISSVOperators, SSVReentrancyGuard {
         uint64 currentBalanceETH = operator.ethSnapshot.balance;
         uint64 currentBalanceSSV = operator.snapshot.balance;
 
-        bool keepValidatorCounts = operator.ethValidatorCount != 0 || operator.validatorCount != 0;
-        operator = _resetOperatorState(operator, keepValidatorCounts);
+        operator = _resetOperatorState(operator);
 
         s.operators[operatorId] = operator;
 
@@ -273,17 +272,16 @@ contract SSVOperators is ISSVOperators, SSVReentrancyGuard {
         }
     }
 
-    function _resetOperatorState(Operator memory operator, bool keepValidatorCounts) private pure returns (Operator memory) {
+    function _resetOperatorState(Operator memory operator) private pure returns (Operator memory) {
         operator.ethSnapshot.block = 0;
         operator.ethSnapshot.balance = 0;
         operator.ethFee = 0;
         operator.snapshot.block = 0;
         operator.snapshot.balance = 0;
         operator.fee = 0;
-        if (!keepValidatorCounts) {
-            operator.ethValidatorCount = 0;
-            operator.validatorCount = 0;
-        }
+        operator.ethValidatorCount = 0;
+        operator.validatorCount = 0;
+        
         return operator;
     }
 


### PR DESCRIPTION
Added 2 functions to handle:
- `updateClusterOperatorsMigration` -> only called when migrating a cluster
- `updateClusterOperators` -> called on ETH cluster regular operations

Same principle as on mainnet: Keep operator indexes for removed operators