### PR TITLE
fix: use EB-weighted balance settlement in registration and removal

### DIFF
--- a/contracts/libraries/ClusterLib.sol
+++ b/contracts/libraries/ClusterLib.sol
@@ -18,22 +18,6 @@ import {PackedSSVLib, PackedETHLib} from "../libraries/SSVPackedLib.sol";
 library ClusterLib {
     using ProtocolLib for StorageProtocol;
 
-    /**
-     * @notice Updates cluster balance by calculating and deducting fees
-     * @param cluster Cluster data
-     * @param newIndex New operator index
-     * @param currentNetworkFeeIndex Current network fee index
-     */
-    function updateBalance(
-        ISSVNetworkCore.Cluster memory cluster,
-        uint64 newIndex,
-        uint64 currentNetworkFeeIndex
-    ) internal pure {
-        uint64 networkFee = uint64(currentNetworkFeeIndex - cluster.networkFeeIndex) * cluster.validatorCount;
-        PackedETH usage = PackedETH.wrap((newIndex - cluster.index) * cluster.validatorCount + networkFee);
-        cluster.balance = PackedETHLib.unpack(usage) > cluster.balance ? 0 : cluster.balance - PackedETHLib.unpack(usage);
-    }
-
     function updateBalanceSSV(
         ISSVNetworkCore.Cluster memory cluster,
         uint64 newIndex,
@@ -166,17 +150,19 @@ library ClusterLib {
     }
 
     /**
-     * @notice Updates cluster data with new indexes
+     * @notice Updates cluster data with new indexes using EB-weighted fee settlement
      * @param cluster Cluster data
+     * @param hashedCluster Hashed cluster ID for EB lookup
      * @param clusterIndex New cluster index
      * @param currentNetworkFeeIndex Current network fee index
      */
     function updateClusterData(
         ISSVNetworkCore.Cluster memory cluster,
+        bytes32 hashedCluster,
         uint64 clusterIndex,
         uint64 currentNetworkFeeIndex
-    ) internal pure {
-        updateBalance(cluster, clusterIndex, currentNetworkFeeIndex);
+    ) internal view {
+        updateBalanceWithEB(cluster, hashedCluster, clusterIndex, currentNetworkFeeIndex);
         cluster.index = clusterIndex;
         cluster.networkFeeIndex = currentNetworkFeeIndex;
     }
@@ -263,7 +249,7 @@ library ClusterLib {
             sp
         );
 
-        updateClusterData(cluster, clusterIndex, sp.currentNetworkFeeIndex());
+        updateClusterData(cluster, hashedCluster, clusterIndex, sp.currentNetworkFeeIndex());
 
         sp.updateDAO(true, validatorCountDelta);
 

--- a/contracts/modules/SSVValidators.sol
+++ b/contracts/modules/SSVValidators.sol
@@ -200,7 +200,7 @@ contract SSVValidators is ISSVValidators {
                 sp
             );
 
-            cluster.updateClusterData(clusterIndex, sp.currentNetworkFeeIndex());
+            cluster.updateClusterData(hashedCluster, clusterIndex, sp.currentNetworkFeeIndex());
 
             sp.updateDAO(false, validatorsRemoved);
         }

--- a/contracts/modules/SSVViews.sol
+++ b/contracts/modules/SSVViews.sol
@@ -233,7 +233,7 @@ contract SSVViews is ISSVViews {
 
         StorageProtocol storage sp = SSVStorageProtocol.load();
 
-        cluster.updateBalance(clusterIndex, sp.currentNetworkFeeIndex());
+        cluster.updateBalanceWithEB(hashedCluster, clusterIndex, sp.currentNetworkFeeIndex());
         return
             cluster.isLiquidatableWithEB(
                 hashedCluster,

--- a/test/echidna/SSVValidatorsEchidna.sol
+++ b/test/echidna/SSVValidatorsEchidna.sol
@@ -160,7 +160,7 @@ contract SSVValidatorsEchidna is SSVValidators {
             if (validatorKeyToId[validatorKey] == validatorId) {
                 validatorKeyToId[validatorKey] = 0;
             }
-            _recordRemoval(clusterRecord, operatorIds);
+            _recordRemoval(clusterRecord, clusterId, operatorIds);
             _updateExpectedOperatorCounts(operatorIds, false);
         } catch {}
     }
@@ -370,7 +370,7 @@ contract SSVValidatorsEchidna is SSVValidators {
         uint64 clusterIndex = _clusterIndexFromStorage(operatorIds, s);
         uint64 networkFeeIndex = sp.currentNetworkFeeIndex();
 
-        cluster.updateClusterData(clusterIndex, networkFeeIndex);
+        cluster.updateClusterData(clusterId, clusterIndex, networkFeeIndex);
         cluster.validatorCount += 1;
         cluster.active = true;
 
@@ -396,7 +396,7 @@ contract SSVValidatorsEchidna is SSVValidators {
         validatorKeyToId[validatorKey] = nextValidatorId;
     }
 
-    function _recordRemoval(ClusterRecord storage record, uint64[] memory operatorIds) internal {
+    function _recordRemoval(ClusterRecord storage record, bytes32 clusterId, uint64[] memory operatorIds) internal {
         if (!record.exists) return;
 
         ISSVNetworkCore.Cluster memory cluster = record.cluster;
@@ -407,7 +407,7 @@ contract SSVValidatorsEchidna is SSVValidators {
             StorageProtocol storage sp = SSVStorageProtocol.load();
             uint64 clusterIndex = _clusterIndexFromStorage(operatorIds, s);
             uint64 networkFeeIndex = sp.currentNetworkFeeIndex();
-            cluster.updateClusterData(clusterIndex, networkFeeIndex);
+            cluster.updateClusterData(clusterId, clusterIndex, networkFeeIndex);
         }
 
         if (cluster.validatorCount > 0) {

--- a/test/unit/SSVClusters/ebAwareSettlement.test.ts
+++ b/test/unit/SSVClusters/ebAwareSettlement.test.ts
@@ -1,0 +1,195 @@
+import { expect } from "chai";
+import type { NetworkConnection } from "hardhat/types/network";
+import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/types";
+import { getTestConnection } from "../../setup/connection.ts";
+import { ssvClustersHarnessFixture } from "../../setup/fixtures.ts";
+import type { NetworkHelpersType } from "../../common/types.ts";
+import { createCluster, makePublicKey, parseClusterFromEvent } from "../../common/helpers.ts";
+import { DEFAULT_SHARES, VUNITS_PRECISION } from "../../common/constants.ts";
+import { Events } from "../../common/events.ts";
+import { ethers } from "ethers";
+
+// ETH_DEDUCTED_DIGITS from SSVPackedLib.sol — ETH fees are packed with 1e5 precision
+const ETH_DEDUCTED_DIGITS = 100_000n;
+
+// Operator fee: 1e10 wei/block (packed = 1e10 / 1e5 = 1e5)
+// Must be divisible by ETH_DEDUCTED_DIGITS
+const OPERATOR_FEE = 10_000_000_000n; // 1e10 wei/block
+
+describe("EB-aware fee settlement on registration and removal", async () => {
+  let connection: NetworkConnection<"generic">;
+  let networkHelpers: NetworkHelpersType;
+  let clusterOwner: HardhatEthersSigner;
+
+  before(async function () {
+    ({ connection, networkHelpers } = await getTestConnection());
+    [clusterOwner] = await connection.ethers.getSigners();
+  });
+
+  const deployClustersWithFee = async () => {
+    return ssvClustersHarnessFixture(connection, 4, OPERATOR_FEE);
+  };
+
+  const getClusterId = (ownerAddress: string, operatorIds: bigint[]): string => {
+    return ethers.keccak256(
+      ethers.solidityPacked(["address", "uint64[]"], [ownerAddress, operatorIds])
+    );
+  };
+
+  const getEBRoot = (clusterId: string, effectiveBalance: number): string => {
+    const coder = ethers.AbiCoder.defaultAbiCoder();
+    const innerHash = ethers.keccak256(coder.encode(["bytes32", "uint32"], [clusterId, effectiveBalance]));
+    return ethers.keccak256(ethers.solidityPacked(["bytes32"], [innerHash]));
+  };
+
+  it("Registration settles fees using EB-weighted vUnits, not flat validatorCount", async function () {
+    const { clusters, operatorIds } = await networkHelpers.loadFixture(deployClustersWithFee);
+
+    // Step 1: Register first validator with large deposit
+    const depositValue = ethers.parseEther("100");
+    const regTx1 = await clusters.registerValidator(
+      makePublicKey(1),
+      operatorIds,
+      DEFAULT_SHARES,
+      createCluster(),
+      { value: depositValue }
+    );
+    const receipt1 = await regTx1.wait();
+    const cluster1 = parseClusterFromEvent(clusters, receipt1, Events.VALIDATOR_ADDED);
+
+    // Step 2: Update EB to 1000 ETH (31.25x baseline of 32 ETH)
+    // vUnits per validator = ceil(1000 * 10000 / 32) = 312500
+    const clusterId = getClusterId(clusterOwner.address, operatorIds);
+    const ebBlockNum = 1;
+    const effectiveBalance = 1000;
+    const root = getEBRoot(clusterId, effectiveBalance);
+    await clusters.mockSetEBRoot(ebBlockNum, root);
+
+    const ebTx = await clusters.updateClusterBalance(
+      ebBlockNum,
+      clusterOwner.address,
+      operatorIds,
+      cluster1,
+      effectiveBalance,
+      []
+    );
+    const ebReceipt = await ebTx.wait();
+    const clusterAfterEB = parseClusterFromEvent(clusters, ebReceipt, Events.CLUSTER_BALANCE_UPDATED);
+
+    // Verify vUnits are set
+    const clusterVUnits = await clusters.getClusterVUnits(clusterId);
+    const expectedVUnits = ((BigInt(effectiveBalance) * VUNITS_PRECISION) + 31n) / 32n;
+    expect(clusterVUnits).to.equal(expectedVUnits);
+
+    // Record balance before advancing blocks
+    const balanceBeforeMine = clusterAfterEB.balance;
+
+    // Step 3: Mine 100 blocks to accrue fees
+    await networkHelpers.mine(100);
+
+    // Step 4: Register a second validator — this triggers fee settlement
+    const regTx2 = await clusters.registerValidator(
+      makePublicKey(2),
+      operatorIds,
+      DEFAULT_SHARES,
+      clusterAfterEB,
+      { value: 0n }
+    );
+    const receipt2 = await regTx2.wait();
+    const clusterAfterReg = parseClusterFromEvent(clusters, receipt2, Events.VALIDATOR_ADDED);
+
+    // Step 5: Verify fees were settled using EB-weighted calculation
+    const balanceAfterReg = clusterAfterReg.balance;
+    const feeDeducted = balanceBeforeMine - balanceAfterReg;
+
+    // Calculate what flat (non-EB) settlement would have been:
+    // packed_op_fee = OPERATOR_FEE / ETH_DEDUCTED_DIGITS = 1e5
+    // flat_usage_packed = 4 operators * 1e5 * ~101 blocks * 1 validator = 40,400,000
+    // flat_usage_expanded = 40,400,000 * 100,000 = 4,040,000,000,000 = ~4e12 wei
+    const packedOpFee = OPERATOR_FEE / ETH_DEDUCTED_DIGITS;
+    const flatUsageExpanded = 4n * packedOpFee * 101n * 1n * ETH_DEDUCTED_DIGITS;
+
+    // With EB-weighted: multiplied by vUnits/VUNITS_PRECISION = 312500/10000 = 31.25x
+    // So EB-aware fee should be ~31.25x the flat fee
+    expect(feeDeducted).to.be.gt(0n, "Fee should have been deducted");
+    expect(feeDeducted).to.be.gt(
+      flatUsageExpanded * 10n,
+      "EB-weighted fee settlement should charge significantly more than flat validatorCount"
+    );
+  });
+
+  it("Removal settles fees using EB-weighted vUnits", async function () {
+    const { clusters, operatorIds } = await networkHelpers.loadFixture(deployClustersWithFee);
+
+    // Register 2 validators
+    const depositValue = ethers.parseEther("100");
+    const regTx1 = await clusters.registerValidator(
+      makePublicKey(1),
+      operatorIds,
+      DEFAULT_SHARES,
+      createCluster(),
+      { value: depositValue }
+    );
+    const receipt1 = await regTx1.wait();
+    const cluster1 = parseClusterFromEvent(clusters, receipt1, Events.VALIDATOR_ADDED);
+
+    const regTx2 = await clusters.registerValidator(
+      makePublicKey(2),
+      operatorIds,
+      DEFAULT_SHARES,
+      cluster1,
+      { value: 0n }
+    );
+    const receipt2 = await regTx2.wait();
+    const cluster2 = parseClusterFromEvent(clusters, receipt2, Events.VALIDATOR_ADDED);
+
+    // Update EB to 500 ETH total for cluster (250 ETH per validator)
+    const clusterId = getClusterId(clusterOwner.address, operatorIds);
+    const ebBlockNum = 1;
+    const effectiveBalance = 500;
+    const root = getEBRoot(clusterId, effectiveBalance);
+    await clusters.mockSetEBRoot(ebBlockNum, root);
+
+    const ebTx = await clusters.updateClusterBalance(
+      ebBlockNum,
+      clusterOwner.address,
+      operatorIds,
+      cluster2,
+      effectiveBalance,
+      []
+    );
+    const ebReceipt = await ebTx.wait();
+    const clusterAfterEB = parseClusterFromEvent(clusters, ebReceipt, Events.CLUSTER_BALANCE_UPDATED);
+
+    const clusterVUnits = await clusters.getClusterVUnits(clusterId);
+    const expectedVUnits = ((BigInt(effectiveBalance) * VUNITS_PRECISION) + 31n) / 32n;
+    expect(clusterVUnits).to.equal(expectedVUnits);
+
+    const balanceBeforeMine = clusterAfterEB.balance;
+
+    // Mine 100 blocks
+    await networkHelpers.mine(100);
+
+    // Remove a validator — triggers fee settlement
+    const removeTx = await clusters.removeValidator(
+      makePublicKey(1),
+      operatorIds,
+      clusterAfterEB
+    );
+    const removeReceipt = await removeTx.wait();
+    const clusterAfterRemove = parseClusterFromEvent(clusters, removeReceipt, Events.VALIDATOR_REMOVED);
+
+    const feeDeducted = balanceBeforeMine - clusterAfterRemove.balance;
+    expect(feeDeducted).to.be.gt(0n, "Fee should have been deducted on removal");
+
+    // flat_usage = 4 * packedOpFee * ~101 blocks * 2 validators * ETH_DEDUCTED_DIGITS
+    const packedOpFee = OPERATOR_FEE / ETH_DEDUCTED_DIGITS;
+    const flatUsageExpanded = 4n * packedOpFee * 101n * 2n * ETH_DEDUCTED_DIGITS;
+
+    // EB-weighted should be significantly higher (vUnits/VUNITS_PRECISION = 156250/10000 ≈ 15.6x)
+    expect(feeDeducted).to.be.gt(
+      flatUsageExpanded * 5n,
+      "EB-weighted fee settlement on removal should charge more than flat validatorCount"
+    );
+  });
+});


### PR DESCRIPTION
Registration (updateClusterOnRegistration) and removal (_bulkRemoveValidator) were settling accrued fees using flat updateBalance() which multiplies by validatorCount, ignoring effective balance. Clusters with high EB were systematically under-charged. SSVViews.isLiquidatable() also settled balance with the non-EB method.

- Make updateClusterData() call updateBalanceWithEB() instead of updateBalance()
- Pass hashedCluster through registration, removal and view call sites
- Remove dead updateBalance() function (no remaining callers)
- Update echidna test harness to match new signatures
- Add unit tests verifying EB-weighted settlement on register and remove