### PR TITLE
Operator getters return default ETH fee if SSV fee is set

### DIFF
--- a/contracts/modules/SSVViews.sol
+++ b/contracts/modules/SSVViews.sol
@@ -46,7 +46,7 @@ contract SSVViews is ISSVViews {
      */
     function getOperatorFee(uint64 operatorId) external view override returns (uint256) {
         ISSVNetworkCore.Operator storage operator = SSVStorage.load().operators[operatorId];
-        if (operator.ethFee.eq(PACKED_ETH_ZERO) && operator.fee.neq(PACKED_SSV_ZERO)) {
+        if (operator.ethSnapshot.block == 0 && operator.fee.neq(PACKED_SSV_ZERO)) {
             return DEFAULT_OPERATOR_ETH_FEE;
         }
         return PackedETHLib.unpack(operator.ethFee);
@@ -86,7 +86,7 @@ contract SSVViews is ISSVViews {
         ISSVNetworkCore.Operator storage operator = SSVStorage.load().operators[operatorId];
 
         op.owner = operator.owner;
-        if (operator.ethFee.eq(PACKED_ETH_ZERO) && operator.fee.neq(PACKED_SSV_ZERO)) {
+        if (operator.ethSnapshot.block == 0 && operator.fee.neq(PACKED_SSV_ZERO)) {
             op.fee = DEFAULT_OPERATOR_ETH_FEE;
         } else {
             op.fee = PackedETHLib.unpack(operator.ethFee);

--- a/contracts/modules/SSVViews.sol
+++ b/contracts/modules/SSVViews.sol
@@ -46,10 +46,11 @@ contract SSVViews is ISSVViews {
      */
     function getOperatorFee(uint64 operatorId) external view override returns (uint256) {
         ISSVNetworkCore.Operator storage operator = SSVStorage.load().operators[operatorId];
-        if (operator.ethSnapshot.block == 0 && operator.fee.neq(PACKED_SSV_ZERO)) {
+        if (operator.ethSnapshot.block != 0) {
+            return PackedETHLib.unpack(operator.ethFee);
+        } else if (PackedSSV.unwrap(operator.fee) != 0) {
             return DEFAULT_OPERATOR_ETH_FEE;
         }
-        return PackedETHLib.unpack(operator.ethFee);
     }
 
     /**

--- a/contracts/modules/SSVViews.sol
+++ b/contracts/modules/SSVViews.sol
@@ -8,7 +8,7 @@ import "../libraries/ClusterLib.sol";
 import "../libraries/OperatorLib.sol";
 import "../libraries/CoreLib.sol";
 import "../libraries/ProtocolLib.sol";
-import {PackedSSV, PackedETH, VERSION_ETH, VERSION_SSV} from "../libraries/SSVCoreTypes.sol";
+import {PackedSSV, PackedETH, PACKED_ETH_ZERO, PACKED_SSV_ZERO, VERSION_ETH, VERSION_SSV, DEFAULT_OPERATOR_ETH_FEE} from "../libraries/SSVCoreTypes.sol";
 import {PackedSSVLib, PackedETHLib} from "../libraries/SSVPackedLib.sol";
 import {SSVStorage, StorageData} from "../libraries/storage/SSVStorage.sol";
 import {SSVStorageProtocol, StorageProtocol} from "../libraries/storage/SSVStorageProtocol.sol";
@@ -45,7 +45,11 @@ contract SSVViews is ISSVViews {
      * @inheritdoc ISSVViews
      */
     function getOperatorFee(uint64 operatorId) external view override returns (uint256) {
-        return PackedETHLib.unpack(SSVStorage.load().operators[operatorId].ethFee);
+        ISSVNetworkCore.Operator storage operator = SSVStorage.load().operators[operatorId];
+        if (operator.ethFee.eq(PACKED_ETH_ZERO) && operator.fee.neq(PACKED_SSV_ZERO)) {
+            return DEFAULT_OPERATOR_ETH_FEE;
+        }
+        return PackedETHLib.unpack(operator.ethFee);
     }
 
     /**
@@ -82,7 +86,11 @@ contract SSVViews is ISSVViews {
         ISSVNetworkCore.Operator storage operator = SSVStorage.load().operators[operatorId];
 
         op.owner = operator.owner;
-        op.fee = PackedETHLib.unpack(operator.ethFee);
+        if (operator.ethFee.eq(PACKED_ETH_ZERO) && operator.fee.neq(PACKED_SSV_ZERO)) {
+            op.fee = DEFAULT_OPERATOR_ETH_FEE;
+        } else {
+            op.fee = PackedETHLib.unpack(operator.ethFee);
+        }
         op.validatorCount = operator.ethValidatorCount;
         op.whitelistedAddress = SSVStorage.load().operatorsWhitelist[operatorId];
         op.isPrivate = operator.whitelisted;

--- a/contracts/modules/SSVViews.sol
+++ b/contracts/modules/SSVViews.sol
@@ -86,11 +86,12 @@ contract SSVViews is ISSVViews {
         ISSVNetworkCore.Operator storage operator = SSVStorage.load().operators[operatorId];
 
         op.owner = operator.owner;
-        if (operator.ethSnapshot.block == 0 && operator.fee.neq(PACKED_SSV_ZERO)) {
-            op.fee = DEFAULT_OPERATOR_ETH_FEE;
-        } else {
+        if (operator.ethSnapshot.block != 0) {
             op.fee = PackedETHLib.unpack(operator.ethFee);
+        } else if (PackedSSV.unwrap(operator.fee) != 0) {
+            op.fee = DEFAULT_OPERATOR_ETH_FEE;
         }
+
         op.validatorCount = operator.ethValidatorCount;
         op.whitelistedAddress = SSVStorage.load().operatorsWhitelist[operatorId];
         op.isPrivate = operator.whitelisted;


### PR DESCRIPTION
Changes: 
1. **`getOperatorFee`** — Changed
2. **`getOperatorById`** — Changed
3. `getBurnRate` — sums ethFee per operator → 0 (Not changed)
4. `isLiquidatable` — uses ethFee for index/burn calc → 0 (Not changed)
5. `getBalance` — uses ethFee for index calc → 0 (Not changed)
6. `getOperatorEarnings` — calls updateSnapshot which uses ethFee (Not changed)


Change:
- Unmigrated SSV operator (ethSnapshot.block == 0, fee > 0) → returns DEFAULT_OPERATOR_ETH_FEE
- Migrated operator who set ethFee to 0 (ethSnapshot.block > 0, ethFee == 0) → returns 0 (their actual fee)
- New ETH operator (ethSnapshot.block > 0, fee == 0) → returns ethFee (their actual fee)
- Free SSV operator (ethSnapshot.block == 0, fee == 0) → returns 0
- Removed operator (both fees zeroed) → returns 0