### PR TITLE
test: regression proof tests for mainnet readiness bugs

### DIFF
--- a/contracts/test/harness/SSVValidatorsHarness.sol
+++ b/contracts/test/harness/SSVValidatorsHarness.sol
@@ -223,4 +223,54 @@ contract SSVValidatorsHarness is SSVValidators {
     function mockSetToken(address token) external {
         SSVStorage.load().token = IERC20(token);
     }
+
+    // ===== Regression test helpers =====
+
+    /// @dev Simulate pre-v2 operator: clear ETH fields, keep SSV fields
+    function mockClearOperatorEthState(uint64 operatorId) external {
+        StorageData storage s = SSVStorage.load();
+        s.operators[operatorId].ethFee = PACKED_ETH_ZERO;
+        s.operators[operatorId].ethSnapshot.block = 0;
+        s.operators[operatorId].ethSnapshot.index = 0;
+        s.operators[operatorId].ethSnapshot.balance = PACKED_ETH_ZERO;
+    }
+
+    /// @dev Simulate removed operator (mirrors SSVClustersHarness.mockRemoveOperator)
+    function mockRemoveOperator(uint64 operatorId) external {
+        StorageData storage s = SSVStorage.load();
+        s.operators[operatorId].snapshot.block = 0;
+        s.operators[operatorId].snapshot.index = 0;
+        s.operators[operatorId].snapshot.balance = PACKED_SSV_ZERO;
+        s.operators[operatorId].ethSnapshot.block = 0;
+        s.operators[operatorId].ethSnapshot.index = 0;
+        s.operators[operatorId].ethSnapshot.balance = PACKED_ETH_ZERO;
+        s.operators[operatorId].validatorCount = 0;
+        s.operators[operatorId].ethValidatorCount = 0;
+    }
+
+    /// @dev Set operator EB deviation for regression tests
+    function mockSetOperatorEthVUnits(uint64 operatorId, uint64 vUnits) external {
+        SSVStorageEB.load().operatorEthVUnits[operatorId] = vUnits;
+    }
+
+    /// @dev Set DAO total EB deviation for regression tests
+    function mockSetDaoTotalEthVUnits(uint64 vUnits) external {
+        SSVStorageProtocol.load().daoTotalEthVUnits = vUnits;
+    }
+
+    /// @dev Get operator SSV snapshot
+    function getOperatorSnapshot(uint64 operatorId) external view returns (uint64 index, uint32 blockNumber, uint64 balance) {
+        ISSVNetworkCore.Snapshot storage snap = SSVStorage.load().operators[operatorId].snapshot;
+        return (snap.index, snap.block, PackedSSV.unwrap(snap.balance));
+    }
+
+    /// @dev Get operator owner
+    function getOperatorOwner(uint64 operatorId) external view returns (address) {
+        return SSVStorage.load().operators[operatorId].owner;
+    }
+
+    /// @dev Get DAO total ETH vUnits
+    function getDaoTotalEthVUnitsValue() external view returns (uint64) {
+        return SSVStorageProtocol.load().daoTotalEthVUnits;
+    }
 }

--- a/test/regression/dao-security.test.ts
+++ b/test/regression/dao-security.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Regression Tests: DAO Security Issues
+ *
+ * These tests assert the CORRECT behavior for governance parameter validation.
+ * They are expected to FAIL on the current code, proving the bugs are real.
+ * Once fixes land, they should flip to passing.
+ *
+ * SEC-1: setQuorumBps(0) should revert — prevents zero-threshold oracle commits
+ * SEC-4: setUnstakeCooldownDuration(0) should revert — prevents instant unstaking
+ */
+import { expect } from "chai";
+import type { NetworkConnection } from "hardhat/types/network";
+import { getTestConnection } from "../setup/connection.ts";
+import { ssvDAOHarnessFixture } from "../setup/fixtures.ts";
+import type { NetworkHelpersType } from "../common/types.ts";
+import { Errors } from "../common/errors.ts";
+
+describe("Regression: DAO Security Issues", async () => {
+  let connection: NetworkConnection<"generic">;
+  let networkHelpers: NetworkHelpersType;
+
+  before(async function () {
+    ({ connection, networkHelpers } = await getTestConnection());
+  });
+
+  const deployDAOFixture = async () => ssvDAOHarnessFixture(connection);
+
+  describe("SEC-1: setQuorumBps(0) should revert", () => {
+    it("Reverts when setting quorum to zero (prevents zero-threshold commits)", async function () {
+      const { dao } = await networkHelpers.loadFixture(deployDAOFixture);
+
+      // A zero quorum means any single oracle can commit a root with 0% weight needed.
+      // This should be rejected to prevent trivial manipulation of the EB oracle system.
+      //
+      // EXPECTED: Reverts with InvalidQuorum
+      // ACTUAL (BUG): Succeeds, setting quorum to 0
+      await expect(dao.setQuorumBps(0))
+        .to.be.revertedWithCustomError(dao, Errors.INVALID_QUORUM);
+    });
+  });
+
+  describe("SEC-4: setUnstakeCooldownDuration(0) should revert", () => {
+    it("Reverts when setting cooldown duration to zero (prevents instant unstaking)", async function () {
+      const { dao } = await networkHelpers.loadFixture(deployDAOFixture);
+
+      // A zero cooldown allows immediate unstaking, bypassing the security
+      // purpose of the cooldown period (preventing flash-loan governance attacks
+      // and ensuring oracle quorum votes reflect genuine stake commitment).
+      //
+      // EXPECTED: The call either reverts, or enforces a minimum duration > 0
+      // ACTUAL (BUG): Succeeds and stores 0, allowing zero cooldown
+      await dao.setUnstakeCooldownDuration(0);
+      const storedDuration = await dao.getCooldownDuration();
+      expect(storedDuration).to.not.equal(0n);
+    });
+  });
+});

--- a/test/regression/operator-staking-bugs.test.ts
+++ b/test/regression/operator-staking-bugs.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Regression Tests: Operator & Staking Bugs
+ *
+ * These tests assert the CORRECT behavior for operator lifecycle and staking rewards.
+ * They are expected to FAIL on the current code, proving the bugs are real.
+ * Once fixes land, they should flip to passing.
+ *
+ * BUG-2: _resetOperatorState doesn't clear operator.owner after removal
+ * BUG-6: Rewards permanently lost when totalStaked == 0 during fee sync
+ */
+import { expect } from "chai";
+import { ethers } from "ethers";
+import type { NetworkConnection } from "hardhat/types/network";
+import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/types";
+import { getTestConnection } from "../setup/connection.ts";
+import { ssvOperatorsHarnessFixture, ssvStakingHarnessFixture } from "../setup/fixtures.ts";
+import type { NetworkHelpersType } from "../common/types.ts";
+import { makeOperatorKey } from "../common/helpers.ts";
+import { MINIMAL_OPERATOR_ETH_FEE } from "../common/constants.ts";
+
+describe("Regression: Operator & Staking Bugs", async () => {
+  let connection: NetworkConnection<"generic">;
+  let networkHelpers: NetworkHelpersType;
+  let owner: HardhatEthersSigner;
+
+  before(async function () {
+    ({ connection, networkHelpers } = await getTestConnection());
+    [owner] = await connection.ethers.getSigners();
+  });
+
+  describe("BUG-2: operator.owner not cleared after removal", () => {
+    const deployOperatorsFixture = async () => ssvOperatorsHarnessFixture(connection);
+
+    it("Clears operator owner to address(0) after removal", async function () {
+      const { operators } = await networkHelpers.loadFixture(deployOperatorsFixture);
+
+      // Register an operator
+      await operators.registerOperator(makeOperatorKey(1), Number(MINIMAL_OPERATOR_ETH_FEE), false);
+
+      // Fund the contract so removal doesn't fail on ETH transfer
+      const operatorsAddress = await operators.getAddress();
+      await connection.ethers.provider.send("hardhat_setBalance", [
+        operatorsAddress,
+        `0x${(10_000_000n).toString(16)}`,
+      ]);
+
+      // Remove the operator
+      await operators.removeOperator(1);
+
+      // After removal, the owner should be cleared to address(0).
+      // This is critical because:
+      // 1. ensureOperatorExist() uses `owner != address(0)` as existence signal
+      // 2. A non-zero owner on a removed operator could bypass existence checks
+      // 3. checkOwner() would still pass for the original owner on a removed operator
+      //
+      // EXPECTED: owner == address(0)
+      // ACTUAL (BUG): owner still set to the original owner address
+      const operatorData = await operators.getOperator(1);
+      expect(operatorData.owner).to.equal(ethers.ZeroAddress);
+    });
+  });
+
+  describe("BUG-6: Rewards lost when totalStaked == 0", () => {
+    const deployStakingFixture = async () => ssvStakingHarnessFixture(connection);
+
+    it("Does not advance pool balance when totalStaked is zero (defers fees)", async function () {
+      const { staking } = await networkHelpers.loadFixture(deployStakingFixture);
+
+      // Set up: fees have accrued but nobody has staked cSSV yet
+      const accruedFees = 1_000_000_000n;
+      await staking.mockSetStakingEthPoolBalance(0n);
+      await staking.mockSetEthDaoBalance(accruedFees);
+
+      // Call syncFees with zero total staked (no cSSV minted)
+      await staking.syncFees();
+
+      // When totalStaked == 0, the pool balance should NOT advance to current DAO balance.
+      // If it advances, the fees between poolBalance=0 and poolBalance=accruedFees are
+      // permanently lost — no staker will ever receive them because accEthPerShare wasn't
+      // incremented (the totalStaked==0 branch skips the accumulator update).
+      //
+      // Next time syncFees runs with totalStaked > 0, the delta is
+      // (newBalance - poolBalance) which would be 0 since poolBalance was already advanced.
+      // Those accrued fees simply vanish.
+      //
+      // The correct behavior is to defer: keep poolBalance at its previous value
+      // until someone stakes, so the full delta is distributed to future stakers.
+      //
+      // EXPECTED: poolBalance remains 0 (fees deferred)
+      // ACTUAL (BUG): poolBalance advances to accruedFees (fees permanently lost)
+      const poolBalance = await staking.getStakingEthPoolBalance();
+      expect(poolBalance).to.equal(0n);
+    });
+  });
+});

--- a/test/regression/validator-cluster-bugs.test.ts
+++ b/test/regression/validator-cluster-bugs.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Regression Tests: Validator & Cluster Bugs
+ *
+ * These tests assert the CORRECT behavior for cluster operations involving EB tracking.
+ * They are expected to FAIL on the current code, proving the bugs are real.
+ * Once fixes land, they should flip to passing.
+ *
+ * BUG-4: Double deviation cleanup on removeValidator for liquidated clusters with explicit EB.
+ *        _executeLiquidation cleans up operatorEthVUnits deviation, but doesn't clear
+ *        ebSnapshot.vUnits. Then removeValidator tries to clean up the same deviation again,
+ *        causing an arithmetic underflow revert.
+ *
+ * ===== VERIFIED FIXED =====
+ * The following bugs from the mainnet readiness checklist have been verified as fixed
+ * in the current codebase:
+ *
+ * BUG-1: ensureETHDefaults overwritten by stale memory copy
+ *   Status: FIXED — Code was refactored so ensureETHDefaults() runs on the storage reference
+ *   at OperatorLib.sol:200 BEFORE the memory copy at line 201. The existing test
+ *   "Initializes ETH defaults for legacy SSV operators" (registerValidator.test.ts:60)
+ *   confirms the fix.
+ *
+ * BUG-3: ensureETHDefaults resurrects removed operators
+ *   Status: NOT EXPLOITABLE — Removed operators have both snapshot.block=0 and
+ *   ethSnapshot.block=0, which causes ensureOperatorExist() (OperatorLib.sol:159-163)
+ *   to revert with OperatorDoesNotExist before ensureETHDefaults() is reached.
+ *
+ * BUG-5: _liquidateAfterEBUpdateIfNeeded condition too strict for ETH-only operators
+ *   Status: FIXED — The condition at SSVClusters.sol:546 now checks only
+ *   op.ethSnapshot.block != 0 (not both snapshots), correctly handling ETH-only operators.
+ */
+import { expect } from "chai";
+import { ethers } from "ethers";
+import type { NetworkConnection } from "hardhat/types/network";
+import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/types";
+import { getTestConnection } from "../setup/connection.ts";
+import { ssvClustersHarnessFixture } from "../setup/fixtures.ts";
+import type { NetworkHelpersType } from "../common/types.ts";
+import { makePublicKey, createCluster, parseClusterFromEvent } from "../common/helpers.ts";
+import {
+  DEFAULT_ETH_REGISTER_VALUE,
+  DEFAULT_SHARES,
+  VUNITS_PRECISION,
+  MINIMAL_OPERATOR_ETH_FEE,
+} from "../common/constants.ts";
+import { Events } from "../common/events.ts";
+
+describe("Regression: Validator & Cluster Bugs", async () => {
+  let connection: NetworkConnection<"generic">;
+  let networkHelpers: NetworkHelpersType;
+  let clusterOwner: HardhatEthersSigner;
+
+  before(async function () {
+    ({ connection, networkHelpers } = await getTestConnection());
+    [clusterOwner] = await connection.ethers.getSigners();
+  });
+
+  const getClusterId = (ownerAddress: string, operatorIds: bigint[]): string => {
+    return connection.ethers.keccak256(
+      connection.ethers.solidityPacked(["address", "uint64[]"], [ownerAddress, operatorIds])
+    );
+  };
+
+  describe("BUG-4: Double deviation cleanup reverts removeValidator on liquidated cluster", () => {
+    const deployClustersFixture = async () =>
+      ssvClustersHarnessFixture(connection, 4, MINIMAL_OPERATOR_ETH_FEE);
+
+    it("Allows removing a validator from a liquidated cluster with explicit EB", async function () {
+      const { clusters, operatorIds } =
+        await networkHelpers.loadFixture(deployClustersFixture);
+
+      // Step 1: Register a validator (creates ETH cluster with validatorCount=1)
+      const publicKey = makePublicKey(1);
+      const registerTx = await clusters.registerValidator(
+        publicKey,
+        operatorIds,
+        DEFAULT_SHARES,
+        createCluster(),
+        { value: DEFAULT_ETH_REGISTER_VALUE }
+      );
+      const registerReceipt = await registerTx.wait();
+      const clusterAfterRegister = parseClusterFromEvent(
+        clusters,
+        registerReceipt,
+        Events.VALIDATOR_ADDED
+      );
+
+      const clusterId = getClusterId(clusterOwner.address, operatorIds);
+
+      // Step 2: Set up explicit EB tracking with deviation
+      // baseline = 1 validator * VUNITS_PRECISION = 10,000
+      // set cluster vUnits to 15,000 (deviation of 5,000 above baseline)
+      const clusterVUnits = VUNITS_PRECISION + 5000n; // 15,000
+      const deviation = 5000n;
+
+      await clusters.mockSetClusterVUnits(clusterId, clusterVUnits);
+
+      // Set per-operator deviation (each operator carries the full deviation of this cluster)
+      for (const opId of operatorIds) {
+        await clusters.mockSetOperatorEthVUnits(opId, deviation);
+      }
+      // Set DAO total deviation (sum across all operators)
+      await clusters.mockSetDaoTotalEthVUnits(deviation * BigInt(operatorIds.length));
+
+      // Step 3: Liquidate the cluster
+      // Owner can self-liquidate without needing the cluster to be liquidatable.
+      // This triggers _executeLiquidation which:
+      //   - Decrements ethValidatorCount (via updateClusterOperators)
+      //   - Cleans up deviation from operatorEthVUnits (subtracts 5000 from each)
+      //   - Cleans up deviation from daoTotalEthVUnits
+      //   - Does NOT clear ebSnapshot.vUnits (stays at 15,000)
+      const liquidateTx = await clusters.liquidate(
+        clusterOwner.address,
+        operatorIds,
+        clusterAfterRegister
+      );
+      const liquidateReceipt = await liquidateTx.wait();
+      const liquidatedCluster = parseClusterFromEvent(
+        clusters,
+        liquidateReceipt,
+        Events.CLUSTER_LIQUIDATED
+      );
+
+      // Verify post-liquidation state:
+      // - Operator deviations cleaned to 0
+      for (const opId of operatorIds) {
+        expect(await clusters.getOperatorEthVUnits(opId)).to.equal(
+          0n,
+          "Operator deviation should be 0 after liquidation cleanup"
+        );
+      }
+      // - But ebSnapshot.vUnits NOT cleared (this is the root cause of the bug)
+      expect(await clusters.getClusterVUnits(clusterId)).to.equal(
+        clusterVUnits,
+        "EB snapshot vUnits should NOT be cleared by liquidation"
+      );
+
+      // Step 4: Remove the validator from the liquidated cluster
+      //
+      // _bulkRemoveValidator flow for liquidated clusters:
+      //   1. Skips operator snapshot updates (cluster.active == false)
+      //   2. cluster.validatorCount -= 1 → 0
+      //   3. Enters EB cleanup: ebSnapshot.vUnits = 15000 > 0
+      //      - Subtracts baseline: ebSnapshot.vUnits -= 10000 → 5000
+      //      - validatorCount == 0, so cleans up remaining: 5000
+      //      - operatorEthVUnits[i] -= 5000 → 0 - 5000 → UNDERFLOW!
+      //
+      // The deviation was already cleaned during liquidation (step 3), but
+      // ebSnapshot.vUnits was not zeroed, so removeValidator tries to clean
+      // it again, causing an arithmetic underflow.
+      //
+      // EXPECTED: Transaction succeeds (deviation already cleaned, skip redundant cleanup)
+      // ACTUAL (BUG): Reverts with Panic(0x11) — arithmetic underflow
+      const removeTx = await clusters.removeValidator(publicKey, operatorIds, liquidatedCluster);
+      await removeTx.wait();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add 5 regression tests that assert **correct behavior** and **FAIL on current code**, proving bugs from the mainnet readiness checklist are real
- Once fixes land, these tests flip to **passing** — serving as a verification harness
- Extends `SSVValidatorsHarness` with helpers for operator state manipulation (pre-v2 simulation, removal, EB deviation)

## Bugs Proven (5 tests, all FAIL)

| ID | Issue | Failure Evidence |
|----|-------|-----------------|
| SEC-1 | `setQuorumBps(0)` accepts zero quorum | "didn't revert" — no minimum check |
| SEC-4 | `setUnstakeCooldownDuration(0)` accepts zero | "expected 0 to not equal 0" — stored 0 |
| BUG-2 | `operator.owner` not cleared on removal | "expected 0xf39F... to equal 0x0000..." |
| BUG-4 | Double EB deviation cleanup on liquidated cluster | Panic 0x11 at SSVValidators.sol:230 |
| BUG-6 | Rewards lost when `totalStaked == 0` | "expected 1000000000 to equal 0" |

## Verified Fixed (documented in test comments)

| ID | Issue | Status |
|----|-------|--------|
| BUG-1 | `ensureETHDefaults` stale memory | Code refactored — correct order |
| BUG-3 | Removed operator resurrection | Blocked by `ensureOperatorExist` |
| BUG-5 | Liquidation condition too strict | Simplified to `ethSnapshot` only |

## Test plan

- [x] All 5 regression tests FAIL (proving bugs exist)
- [x] Existing unit tests unaffected (360 passing, 2 pre-existing gas failures)
- [x] Contracts compile cleanly
- [ ] After fixes: all 5 tests should PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)