### PR TITLE
fix(SEC-2): initialize quorumBps in upgrade initializer

### DIFF
--- a/contracts/upgrades/stage/hoodi/SSVNetworkSSVStakingUpgrade.sol
+++ b/contracts/upgrades/stage/hoodi/SSVNetworkSSVStakingUpgrade.sol
@@ -7,14 +7,19 @@ import {MAX_DELEGATION_SLOTS} from "../../../libraries/storage/SSVStorageStaking
 contract SSVNetworkSSVStakingUpgrade is SSVNetwork {
     function initializeSSVStaking(
         uint64 cooldownDuration,
-        uint32[MAX_DELEGATION_SLOTS] memory defaultOracleIds
+        uint32[MAX_DELEGATION_SLOTS] memory defaultOracleIds,
+        uint16 quorumBps
     ) external onlyOwner reinitializer(3) {
+        if (quorumBps == 0 || quorumBps > 10_000) revert InvalidQuorum();
+
         // save staking storage updates
         StorageStaking storage s = SSVStorageStaking.load();
         s.cooldownDuration = cooldownDuration;
         s.defaultOracleIds = defaultOracleIds;
+        s.quorumBps = quorumBps;
 
         emit CooldownDurationUpdated(cooldownDuration);
+        emit QuorumUpdated(quorumBps);
         emit SSVNetworkUpgradeBlock("v2.0.0", block.number);
     }
 }

--- a/scripts/deploy-all.ts
+++ b/scripts/deploy-all.ts
@@ -105,8 +105,8 @@ async function main() {
     networkProxyAddr,
     upgradeImplAddr,
     "SSVNetworkSSVStakingUpgrade",
-    "initializeSSVStaking(address,uint64)",
-    [cssvTokenAddr, cooldown]
+    "initializeSSVStaking(uint64,uint32[4],uint16)",
+    [cooldown, defaultOracleIds, quorumBps]
   );
 }
 

--- a/scripts/staking-upgrade.ts
+++ b/scripts/staking-upgrade.ts
@@ -20,6 +20,7 @@ async function main() {
 
   const cooldown = DEFAULT_UNSTAKE_COOLDOWN;
   const defaultOracles = [1,2,3,4];
+  const quorumBps = 7500;
 
   await upgradeProxy(
     ethers,
@@ -27,8 +28,8 @@ async function main() {
     networkProxyAddr,
     upgradeImplAddr,
     "SSVNetworkSSVStakingUpgrade",
-    "initializeSSVStaking(uint64,uint32[4])",
-    [cooldown, defaultOracles]
+    "initializeSSVStaking(uint64,uint32[4],uint16)",
+    [cooldown, defaultOracles, quorumBps]
   );
 }
 

--- a/scripts/upgrade-fork.ts
+++ b/scripts/upgrade-fork.ts
@@ -441,10 +441,13 @@ async function main() {
   console.log("[4/6] Upgrading network proxy and views proxy");
   // Perform staking upgrade first to run reinitializer(3) against the existing proxy.
   // Doing this after upgrading to the latest base implementation may change reinitializer behavior.
+  if (quorumBps === undefined) {
+    throw new Error("quorumBps is required in config for staking upgrade initializer");
+  }
   const upgradeFactory = await ethers.getContractFactory("SSVNetworkSSVStakingUpgrade");
   const initData = upgradeFactory.interface.encodeFunctionData(
-    "initializeSSVStaking(uint64,uint32[4])",
-    [cooldownDuration, defaultOracleIds]
+    "initializeSSVStaking(uint64,uint32[4],uint16)",
+    [cooldownDuration, defaultOracleIds, quorumBps]
   );
   await (await networkOwner.upgradeToAndCall(stakingUpgradeImplAddr, initData)).wait();
   // await (await networkOwner.upgradeTo(networkImplAddr)).wait();

--- a/scripts/upgrade-hoodi.ts
+++ b/scripts/upgrade-hoodi.ts
@@ -342,10 +342,13 @@ async function main() {
   console.log("[4/6] Upgrading network proxy and views proxy");
   // Perform staking upgrade first to run reinitializer(3) against the existing proxy.
   // Doing this after upgrading to the latest base implementation may change reinitializer behavior.
+  if (quorumBps === undefined) {
+    throw new Error("quorumBps is required in config for staking upgrade initializer");
+  }
   const upgradeFactory = await ethers.getContractFactory("SSVNetworkSSVStakingUpgrade");
   const initData = upgradeFactory.interface.encodeFunctionData(
-    "initializeSSVStaking(uint64,uint32[4])",
-    [cooldownDuration, defaultOracleIds]
+    "initializeSSVStaking(uint64,uint32[4],uint16)",
+    [cooldownDuration, defaultOracleIds, quorumBps]
   );
   await (await networkOwner.upgradeToAndCall(stakingUpgradeImplAddr, initData)).wait();
   // await (await networkOwner.upgradeTo(networkImplAddr)).wait();

--- a/test/setup/fixtures.ts
+++ b/test/setup/fixtures.ts
@@ -302,10 +302,11 @@ export async function ssvNetworkFullFixture(
     networkProxyAddr,
     upgradeImplAddr,
     "SSVNetworkSSVStakingUpgrade",
-    "initializeSSVStaking(uint64,uint32[4])",
+    "initializeSSVStaking(uint64,uint32[4],uint16)",
     [
       cooldown,
-      DEFAULT_ORACLE_IDS
+      DEFAULT_ORACLE_IDS,
+      QUORUM_BPS
     ]
   );
 
@@ -381,8 +382,8 @@ export async function ssvNetworkFullForkedFixture(
     const cooldown = DEFAULT_UNSTAKE_COOLDOWN;
     const upgradeFactory = await ethers.getContractFactory("SSVNetworkSSVStakingUpgrade");
     const initData = upgradeFactory.interface.encodeFunctionData(
-      "initializeSSVStaking(uint64,uint32[4])",
-      [cooldown, DEFAULT_ORACLE_IDS]
+      "initializeSSVStaking(uint64,uint32[4],uint16)",
+      [cooldown, DEFAULT_ORACLE_IDS, QUORUM_BPS]
     );
 
     try {


### PR DESCRIPTION
## Summary
- Add `quorumBps` parameter to `initializeSSVStaking` so quorum is set atomically during upgrade
- Without this, `quorumBps` defaults to 0 after upgrade, allowing any single oracle to commit arbitrary Merkle roots
- Adds validation: `quorumBps` must be > 0 and <= 10000
- Also fixes DEPLOY-1: corrects `deploy-all.ts` broken function signature

## Changes
- `SSVNetworkSSVStakingUpgrade.sol`: Added `uint16 quorumBps` param with validation, storage write, and event emission
- `staking-upgrade.ts`, `deploy-all.ts`, `upgrade-fork.ts`, `upgrade-hoodi.ts`: Updated function signatures and params
- `test/setup/fixtures.ts`: Updated both fixture functions with `QUORUM_BPS`

## Test plan
- [x] `npx hardhat compile` passes
- [x] `npm run test` passes (11 pre-existing gas assertion failures only)
- [ ] Verify quorumBps is correctly set after upgrade in fork test

🤖 Generated with [Claude Code](https://claude.com/claude-code)