### PR TITLE
S-7	Code quality improvements (cluster invariants, reentrancy)

### DIFF
--- a/contracts/libraries/ClusterLib.sol
+++ b/contracts/libraries/ClusterLib.sol
@@ -341,13 +341,18 @@ library ClusterLib {
         StorageData storage s
     ) internal view returns (bytes32 clusterData, uint8 version) {
         clusterData = s.ethClusters[hashedCluster];
+        bytes32 clusterDataSSV = s.clusters[hashedCluster];
+
+        if (clusterData != bytes32(0) && clusterDataSSV != bytes32(0)) {
+            revert ISSVNetworkCore.IncorrectClusterState();
+        }
+
         if (clusterData != bytes32(0)) {
             return (clusterData, VERSION_ETH);
         }
 
-        clusterData = s.clusters[hashedCluster];
-        if (clusterData != bytes32(0)) {
-            return (clusterData, VERSION_SSV);
+        if (clusterDataSSV != bytes32(0)) {
+            return (clusterDataSSV, VERSION_SSV);
         }
 
         revert ISSVNetworkCore.ClusterDoesNotExist();

--- a/contracts/modules/SSVClusters.sol
+++ b/contracts/modules/SSVClusters.sol
@@ -133,7 +133,7 @@ contract SSVClusters is ISSVClusters, SSVReentrancyGuard {
     function reactivate(
         uint64[] calldata operatorIds,
         Cluster memory cluster
-    ) external payable override {
+    ) external payable override nonReentrant {
         StorageData storage s = SSVStorage.load();
 
         (bytes32 hashedCluster, uint8 version) = cluster.validateHashedCluster(msg.sender, operatorIds, s);

--- a/contracts/modules/SSVStaking.sol
+++ b/contracts/modules/SSVStaking.sol
@@ -41,10 +41,6 @@ contract SSVStaking is ISSVStaking, SSVReentrancyGuard {
      * @inheritdoc ISSVStaking
      */
     function stake(uint256 amount) external nonReentrant {
-        if (amount == 0) {
-            revert ZeroAmount();
-        }
-
         if (amount < MINIMAL_STAKING_AMOUNT) {
             revert StakeTooLow();
         }

--- a/contracts/test/mocks/MaliciousReactivate.sol
+++ b/contracts/test/mocks/MaliciousReactivate.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {ISSVClusters} from "../../interfaces/ISSVClusters.sol";
+import {ISSVValidators} from "../../interfaces/ISSVValidators.sol";
+import {ISSVNetworkCore} from "../../interfaces/ISSVNetworkCore.sol";
+
+contract MaliciousReactivate {
+    address public ssvNetwork;
+    uint64[] public ops;
+    ISSVNetworkCore.Cluster public cl;
+
+    uint64[] public reactivateOps;
+    ISSVNetworkCore.Cluster public reactivateCl;
+
+    constructor(address _ssvNetwork) {
+        ssvNetwork = _ssvNetwork;
+    }
+
+    function setParams(
+        uint64[] memory _ops,
+        ISSVNetworkCore.Cluster memory _cl
+    ) external {
+        ops = _ops;
+        cl = _cl;
+    }
+
+    function setReactivateParams(
+        uint64[] memory _ops,
+        ISSVNetworkCore.Cluster memory _cl
+    ) external {
+        reactivateOps = _ops;
+        reactivateCl = _cl;
+    }
+
+    function registerValidator(
+        bytes calldata publicKey,
+        uint64[] calldata operatorIds,
+        bytes calldata sharesData,
+        ISSVNetworkCore.Cluster memory cluster
+    ) external payable {
+        ISSVValidators(ssvNetwork).registerValidator{value: msg.value}(publicKey, operatorIds, sharesData, cluster);
+    }
+
+    function attack() external {
+        ISSVClusters(ssvNetwork).withdraw(ops, 1, cl);
+    }
+
+    receive() external payable {
+        ISSVClusters(ssvNetwork).reactivate{value: msg.value}(reactivateOps, reactivateCl);
+    }
+}

--- a/test/e2e/staking/staking-edge-cases.test.ts
+++ b/test/e2e/staking/staking-edge-cases.test.ts
@@ -316,13 +316,13 @@ describe("E2E Staking Edge Cases", () => {
   });
 
   describe("MINIMAL_STAKING_AMOUNT", () => {
-    it("Should revert with ZeroAmount for stake(0)", async function () {
+    it("Should revert with StakeTooLow for stake(0)", async function () {
       const { network } =
         await networkHelpers.loadFixture(deployFixture);
 
       await expect(
         network.connect(stakerA).stake(0n),
-      ).to.be.revertedWithCustomError(network, Errors.ZERO_AMOUNT);
+      ).to.be.revertedWithCustomError(network, Errors.STAKE_TOO_LOW);
     });
 
     it("Should revert with StakeTooLow for amount below minimum", async function () {

--- a/test/integration/SSVNetwork.test.ts
+++ b/test/integration/SSVNetwork.test.ts
@@ -2927,12 +2927,12 @@ describe("SSVNetwork full integration tests", () => {
         .to.be.revertedWithCustomError(network, Errors.STAKE_TOO_LOW);
     });
 
-    it("Is reverted with 'ZeroAmount' is caller is trying to stake 0 SSV", async function(){
+    it("Is reverted with 'StakeTooLow' is caller is trying to stake 0 SSV", async function(){
       const { network } =
         await networkHelpers.loadFixture(deployFullSSVNetworkFixture);
 
       await expect(network.stake(0))
-        .to.be.revertedWithCustomError(network, Errors.ZERO_AMOUNT);
+        .to.be.revertedWithCustomError(network, Errors.STAKE_TOO_LOW);
     });
   });
 
@@ -3544,6 +3544,31 @@ describe("SSVNetwork full integration tests", () => {
       }
       await updateClusterBalancesForDefaultClusters(network, clusters, merkleData, blockNum, 33);
 
+      await expect(malicious.attack()).to.be.revertedWithCustomError(network, Errors.ETH_TRANSFER_FAILED);
+    });
+
+    it("Prevents reentrancy in 'reactivate()'", async function () {
+      const { network } = await networkHelpers.loadFixture(deployFullSSVNetworkFixture);
+      const operatorIds = await registerOperators(network, operatorOwner, 4);
+
+      const Malicious = await connection.ethers.getContractFactory("MaliciousReactivate");
+      const malicious = await Malicious.deploy(await network.getAddress());
+      await malicious.waitForDeployment();
+
+      await whitelistAddresses(network, operatorOwner, operatorIds, [await malicious.getAddress()]);
+
+      await malicious.registerValidator(
+        makePublicKey(1),
+        operatorIds,
+        DEFAULT_SHARES,
+        EMPTY_CLUSTER,
+        { value: DEFAULT_ETH_REGISTER_VALUE }
+      );
+
+      const cluster = await getCurrentClusterState(connection, network, await malicious.getAddress(), operatorIds);
+
+      await malicious.setParams(operatorIds, cluster);
+      await malicious.setReactivateParams(operatorIds, cluster);
       await expect(malicious.attack()).to.be.revertedWithCustomError(network, Errors.ETH_TRANSFER_FAILED);
     });
 

--- a/test/integration/SSVNetwork/staking.test.ts
+++ b/test/integration/SSVNetwork/staking.test.ts
@@ -462,7 +462,7 @@ describe("SSVNetwork Integration - Staking (Enhanced)", () => {
     it("Cannot stake zero amount", async function() {
       const { network } = await networkHelpers.loadFixture(deployFullSSVNetworkFixture);
 
-      await expect(network.stake(0)).to.be.revertedWithCustomError(network, Errors.ZERO_AMOUNT);
+      await expect(network.stake(0)).to.be.revertedWithCustomError(network, Errors.STAKE_TOO_LOW);
     });
 
     it("Cannot stake below minimum stake amount", async function() {

--- a/test/test-forked/v2.0.0/fullIntegrationForked.test.ts
+++ b/test/test-forked/v2.0.0/fullIntegrationForked.test.ts
@@ -2391,12 +2391,12 @@ suite("SSVNetwork full integration tests made on forked contract", () => {
         .to.be.revertedWithCustomError(network, Errors.STAKE_TOO_LOW);
     });
 
-    it("Is reverted with 'ZeroAmount' is caller is trying to stake 0 SSV", async function(){
+    it("Is reverted with 'StakeTooLow' is caller is trying to stake 0 SSV", async function(){
       const { network } =
         await networkHelpers.loadFixture(deployFullSSVNetworkForkFixture);
 
       await expect(network.stake(0))
-        .to.be.revertedWithCustomError(network, Errors.ZERO_AMOUNT);
+        .to.be.revertedWithCustomError(network, Errors.STAKE_TOO_LOW);
     });
   });
 

--- a/test/unit/SSVStaking/stake.test.ts
+++ b/test/unit/SSVStaking/stake.test.ts
@@ -85,13 +85,13 @@ describe("SSVStaking function `stake()`", async () => {
       .withArgs(staker.address, minAmount);
   });
 
-  it("Is reverted with 'ZeroAmount' when staking zero amount", async function () {
+  it("Is reverted with 'StakeTooLow' when staking zero amount", async function () {
     const { staking } =
       await networkHelpers.loadFixture(deployStakingFixture);
 
     await expect(staking.stake(0n)).to.be.revertedWithCustomError(
       staking,
-      Errors.ZERO_AMOUNT
+      Errors.STAKE_TOO_LOW
     );
   });
 


### PR DESCRIPTION
  - Add dual-mapping invariant check in ClusterLib.getClusterData — reverts if both ethClusters and clusters are populated for the same key
  - Remove redundant amount == 0 check in SSVStaking.stake — already covered by MINIMAL_STAKING_AMOUNT                                                                         
  - Add nonReentrant guard to reactivate for consistency with other cluster lifecycle functions                                                                                
  - Add reentrancy integration test for reactivate