### PR TITLE
Deployment: Include json hashes in the deployment output message

### DIFF
--- a/docs/UPGRADE_PLAYBOOK.md
+++ b/docs/UPGRADE_PLAYBOOK.md
@@ -174,6 +174,8 @@ cast keccak $(cast code <address> --rpc-url $MAINNET_RPC_URL)
 
 The expected values should be derived from the locally compiled artifacts in `artifacts/build-info/` or by running the same command against the staging deployment. Include the full attestation JSON in the delivery to the committee.
 
+The script also prints the `keccak256` file hashes of `deployment-attestation.json` and `multisig-batch.json` (if already generated). The committee should verify these hashes match the files they received to confirm nothing was modified after generation.
+
 ## Step 2: Generate the SAFE Batch
 
 After the implementation deployment is complete, SSV Labs runs:

--- a/scripts/generate-deployment-attestation.ts
+++ b/scripts/generate-deployment-attestation.ts
@@ -208,6 +208,19 @@ async function main() {
   await writeFile(outputPath, `${JSON.stringify(attestation, null, 2)}\n`, "utf8");
   console.log(`\nAttestation written to: ${outputPath}`);
 
+  // Compute file hashes for committee verification
+  const attestationContent = await readFile(outputPath, "utf8");
+  const attestationFileHash = keccak256(new TextEncoder().encode(attestationContent));
+
+  const batchPath = join(resolveEnvDir(envFlag), "multisig-batch.json");
+  let batchFileHash: string | null = null;
+  try {
+    const batchContent = await readFile(batchPath, "utf8");
+    batchFileHash = keccak256(new TextEncoder().encode(batchContent));
+  } catch {
+    console.warn(`Warning: ${batchPath} not found — run 'just generate-safe-batch' first to include its hash.`);
+  }
+
   // Print human-readable summary
   console.log("\n" + "=".repeat(80));
   console.log("SSV Network Deployment Attestation");
@@ -246,6 +259,13 @@ async function main() {
   console.log("-".repeat(80));
   for (const [id, addr] of Object.entries(oracles)) {
     console.log(`  Oracle ${id}: ${addr}`);
+  }
+  console.log("");
+  console.log("File Hashes (keccak256 — for committee verification):");
+  console.log("-".repeat(80));
+  console.log(`  deployment-attestation.json: ${attestationFileHash}`);
+  if (batchFileHash) {
+    console.log(`  multisig-batch.json:         ${batchFileHash}`);
   }
   console.log("=".repeat(80));
 }


### PR DESCRIPTION
Request from the m-sig. Add this section to the message to be signed after deployment:
```
File Hashes (keccak256 — for committee verification):
--------------------------------------------------------------------------------
  deployment-attestation.json: 0x2ededfebf9227420c146d4f761a8b10b2e6fca0b2939d175674cccafddc6218f
  multisig-batch.json:         0x8d8d4062bb4b1b9c2f0ff960dba360f7411fd1c5a8c15c490
```