### PR TITLE
chore(ci) - Update actions base image to node:24

### DIFF
--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Solidity code coverage
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-node@v6.3.0
         with:
           node-version: '22.x'
       - run: npm ci

--- a/.github/workflows/echidna.yaml
+++ b/.github/workflows/echidna.yaml
@@ -16,7 +16,7 @@ jobs:
       contracts: ${{ steps.discover.outputs.contracts }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           submodules: recursive
 
@@ -44,12 +44,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           submodules: recursive
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.3.0
         with:
           node-version: '22.x'
           cache: 'npm'
@@ -72,7 +72,7 @@ jobs:
           test-mode: property
 
       - name: Upload corpus
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: echidna-corpus-${{ matrix.contract }}

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Solidity linter
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-node@v6.3.0
         with:
           node-version: '22.x'
       - run: npm ci

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,7 +8,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - name: Use Node.js
         uses: actions/setup-node@v6.3.0
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.3.0
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/slither.yaml
+++ b/.github/workflows/slither.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -21,7 +21,7 @@ jobs:
         run: npx hardhat compile --force
 
       - name: Run Slither
-        uses: crytic/slither-action@v0.3.2
+        uses: crytic/slither-action@v0.4.2
         id: slither
         with:
           fail-on: high

--- a/.github/workflows/slither.yaml
+++ b/.github/workflows/slither.yaml
@@ -8,7 +8,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.3.0
         with:
           node-version: '22.x'
 

--- a/.github/workflows/tests-forked.yaml
+++ b/.github/workflows/tests-forked.yaml
@@ -12,9 +12,8 @@ jobs:
       HOODI_RPC_URL: ${{ secrets.hoodi_rpc_url }}
       MAINNET_RPC_URL: ${{ secrets.mainnet_rpc_url }}
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-node@v6.3.0
         with:
           node-version: '22.x'
           cache: 'npm'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,14 +38,14 @@ jobs:
         continue-on-error: false
 
       - name: Upload gas report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: gas-report
           path: gas-report.json
           retention-days: 30
 
       - name: Upload gas comparison report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: gas-compare
           path: gas-compare.txt
@@ -53,7 +53,7 @@ jobs:
 
       - name: Comment on PR with gas report
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,9 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Hardhat unit test
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6.0.2
+      - uses: actions/setup-node@v6.3.0
         with:
           node-version: '22.x'
           cache: 'npm'


### PR DESCRIPTION
## Summary
GitHub is enforcing Node.js 24 for GitHub Actions runtime and will block workflows that rely on older Node runtimes.

This PR updates CI workflows to align with the requirement.

## Changes
- Update reusable action references (`uses:`) to latest released versions.
- Update workflow Node container images (`node:<version>`) to `node:24` where they were below 24.