### PR TITLE
[just] attach-module recipe uses env param

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -94,10 +94,9 @@ deploy-module module network *args:
     npx hardhat compile --force
     npx tsx scripts/deploy-module.ts --network {{network}} --module {{module}} {{ if args == "" { "" } else { "--args '[\"" + replace(args, " ", "\",\"") + "\"]'" } }}
 
-# Attach an existing deployed module to the proxy
-attach-module module module-address proxy-address network:
-    npx hardhat compile --force
-    npx tsx scripts/attach-module.ts --network {{network}} --module {{module}} --module-address {{module-address}} --proxy-address {{proxy-address}}
+# Attach an existing deployed module to the env-configured proxy
+attach-module env module module-address network="":
+    npx tsx scripts/attach-module.ts --env {{env}} --module {{module}} --module-address {{module-address}} {{ if network == "" { "" } else { "--network " + network } }}
 
 # Upgrade a contract via UUPS proxy pattern (optionally with pre-deployed impl)
 upgrade-contract contract proxy network *impl:

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -108,6 +108,7 @@ This prevents running the wrong config against the wrong proxy.
 | `generate-deployment-attestation.ts` | `just generate-attestation <env>` | Bytecode hashes + config attestation for committee |
 | `generate-safe-batch.ts` | `just generate-safe-batch <env>` | Encode SAFE multisig batch |
 | `deploy-fresh.ts` | `just deploy-fresh <env>` | Full greenfield deployment |
+| `attach-module.ts` | `just attach-module <env> <module> <module-address>` | Attach one module to the env-configured proxy and update the latest deploy-result |
 | `run-forked-tests.ts` | `just test-fork <env>` | Integration tests against fork |
 
 ## Troubleshooting

--- a/scripts/attach-module.ts
+++ b/scripts/attach-module.ts
@@ -1,14 +1,71 @@
-import { parseArg, getEthers, attachModule } from "./common/helpers.ts";
+import { readFile, realpath, writeFile } from "node:fs/promises";
+import { attachModule, getEthers, parseArg } from "./common/helpers.ts";
+import {
+  type ModuleAddressesConfig,
+  type ModuleName,
+  type UpgradeConfig,
+  parseOptionalArg,
+  requireAddress,
+  resolveConfigPath,
+  resolveDeployResultPath,
+  resolveNetworkFromEnv,
+} from "./common/config.ts";
+
+type AttachModuleDeployResult = {
+  modules?: ModuleAddressesConfig;
+  updatedAt?: string;
+  [key: string]: unknown;
+};
+
+async function updateLatestDeployResult(
+  env: string,
+  moduleName: ModuleName,
+  moduleAddress: string
+): Promise<string> {
+  const latestResultPath = resolveDeployResultPath(env);
+  const versionedResultPath = await realpath(latestResultPath).catch(() => latestResultPath);
+  const raw = await readFile(versionedResultPath, "utf8");
+  const deployResult = JSON.parse(raw) as AttachModuleDeployResult;
+
+  deployResult.modules = {
+    ...(deployResult.modules ?? {}),
+    [moduleName]: moduleAddress,
+  };
+  deployResult.updatedAt = new Date().toISOString();
+
+  await writeFile(versionedResultPath, `${JSON.stringify(deployResult, null, 2)}\n`, "utf8");
+  return versionedResultPath;
+}
 
 async function main() {
-  const targetNetwork = parseArg("network");
-  const ethers = await getEthers(targetNetwork);
+  const envFlag = parseArg("env");
+  const moduleName = parseArg("module") as ModuleName;
+  const moduleAddress = requireAddress(parseArg("module-address"), "module-address");
+  const configPath = resolveConfigPath(envFlag);
+  const rawConfig = await readFile(configPath, "utf8");
+  const config = JSON.parse(rawConfig) as UpgradeConfig;
 
-  const moduleName = parseArg("module");
-  const moduleAddress = parseArg("module-address");
-  const proxyAddress = parseArg("proxy-address");
+  const targetNetwork = parseOptionalArg("network") ?? resolveNetworkFromEnv(envFlag) ?? "local";
+  const proxyAddress = requireAddress(config.ssvNetworkProxy, "ssvNetworkProxy");
+
+  console.log(`Environment: ${envFlag}`);
+  console.log(`Resolved SSVNetwork proxy from config: ${proxyAddress}`);
+
+  const ethers = await getEthers(targetNetwork);
+  const proxyCode = await ethers.provider.getCode(proxyAddress);
+  if (proxyCode === "0x") {
+    throw new Error(`No contract code at proxy ${proxyAddress} on ${targetNetwork}`);
+  }
+
+  const moduleCode = await ethers.provider.getCode(moduleAddress);
+  if (moduleCode === "0x") {
+    throw new Error(`No contract code at module ${moduleAddress} on ${targetNetwork}`);
+  }
 
   await attachModule(ethers, proxyAddress, moduleName, moduleAddress);
+
+  const updatedResultPath = await updateLatestDeployResult(envFlag, moduleName, moduleAddress);
+  console.log(`Updated deploy result: ${updatedResultPath}`);
 }
 
 main().catch((err) => {

--- a/scripts/deployment.md
+++ b/scripts/deployment.md
@@ -86,7 +86,7 @@ just deploy-module SSVOperators hoodi 12345
 ### Attach a pre-deployed module
 
 ```bash
-just attach-module SSVClusters 0xMODULE 0xPROXY hoodi
+just attach-module hoodi-stage SSVClusters 0xMODULE
 ```
 
 ## Important Notes


### PR DESCRIPTION
`env` param added to `attach-module` recipe to require the correct target `SSVNetwork` proxy and update the latest deployment file.