### PR TITLE
Sepolia env deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,18 @@
 # ── RPC endpoints ──
 MAINNET_RPC_URL=
 HOODI_RPC_URL=
+SEPOLIA_RPC_URL=
 
 # ── Signer private keys ──
 # Must match the on-chain owner for live upgrades.
 MAINNET_PRIVATE_KEY=
 HOODI_PRIVATE_KEY=
+SEPOLIA_PRIVATE_KEY=
 
 # ── Optional SSV token address overrides for Hardhat network config ──
 MAINNET_SSVTOKEN_ADDRESS=
 HOODI_SSVTOKEN_ADDRESS=
+SEPOLIA_SSVTOKEN_ADDRESS=
 
 # ── Block explorer verification ──
 ETHERSCAN_KEY=

--- a/deployments/sepolia/config.json
+++ b/deployments/sepolia/config.json
@@ -1,0 +1,31 @@
+{
+  "currentVersion": "v1.2.0",
+  "targetVersion": "v2.0.0",
+  "skipInitializer": false,
+  "owner": "0xC564AF154621Ee8D0589758d535511aEc8f67b40",
+  "ssvNetworkProxy": "0x261419B48F36EdF420743E9f91bABF4856e76f99",
+  "ssvNetworkViews": "0xa2A44482e752D3D956AAFaA94CFDD21Aacfc2959",
+  "ssvToken": "0x116522F4D00b42Efce0aA77f7ddAd1d27705F36b",
+  "cooldownDuration": 604800,
+  "upgradeTimestamp": 1783500000,
+  "quorumBps": 7500,
+  "defaultOracleIds": [1, 2, 3, 4],
+  "protocolParams": {
+    "networkFeeEth": "3550900000",
+    "maxOperatorEthFee": "5326300000",
+    "minOperatorEthFee": "1065200000",
+    "minimumLiquidationCollateralEth": "940000000000000",
+    "liquidationThresholdPeriod": "35800",
+    "minBlocksBetweenUpdates": "0",
+    "operatorFeeIncreaseLimit": "1000",
+    "declareOperatorFeePeriod": "604800",
+    "executeOperatorFeePeriod": "604800"
+  },
+  "initialStakeAmount": "1000000000000000000",
+  "oracles": {
+    "1": "0x011684890d10eCC4473F2A4A8B0F2cb7F19C66EB",
+    "2": "0x0CBA9a4c9B2Ea64827C101946E8979c1023fE15C",
+    "3": "0xaBE4A01beDF8f0B5984648f2fE64a7A120Dab800",
+    "4": "0xa70d0d0BE1F02cF646D5CDB6716a509A937f3EE5"
+  }
+}

--- a/deployments/sepolia/upgrade-result.json
+++ b/deployments/sepolia/upgrade-result.json
@@ -1,0 +1,1 @@
+upgrade-result.v2.0.0.json

--- a/deployments/sepolia/upgrade-result.v2.0.0.json
+++ b/deployments/sepolia/upgrade-result.v2.0.0.json
@@ -1,0 +1,70 @@
+{
+  "currentVersion": "v1.2.0",
+  "targetVersion": "v2.0.0",
+  "skipInitializer": false,
+  "owner": "0xC564AF154621Ee8D0589758d535511aEc8f67b40",
+  "ssvNetworkProxy": "0x261419B48F36EdF420743E9f91bABF4856e76f99",
+  "ssvNetworkViews": "0xa2A44482e752D3D956AAFaA94CFDD21Aacfc2959",
+  "ssvToken": "0x116522F4D00b42Efce0aA77f7ddAd1d27705F36b",
+  "cooldownDuration": 604800,
+  "upgradeTimestamp": 1783500000,
+  "quorumBps": 7500,
+  "defaultOracleIds": [
+    1,
+    2,
+    3,
+    4
+  ],
+  "protocolParams": {
+    "networkFeeEth": "3550900000",
+    "maxOperatorEthFee": "5326300000",
+    "minOperatorEthFee": "1065200000",
+    "minimumLiquidationCollateralEth": "940000000000000",
+    "liquidationThresholdPeriod": "35800",
+    "minBlocksBetweenUpdates": 0,
+    "operatorFeeIncreaseLimit": "1000",
+    "declareOperatorFeePeriod": "604800",
+    "executeOperatorFeePeriod": "604800",
+    "networkFeeSSV": "0",
+    "liquidationThresholdPeriodSSV": "214800",
+    "minimumLiquidationCollateralSSV": "1000000000000000000",
+    "validatorsPerOperatorLimit": "1000",
+    "unstakeCooldownDuration": "604800"
+  },
+  "initialStakeAmount": "1000000000000000000",
+  "oracles": {
+    "1": "0x011684890d10eCC4473F2A4A8B0F2cb7F19C66EB",
+    "2": "0x0CBA9a4c9B2Ea64827C101946E8979c1023fE15C",
+    "3": "0xaBE4A01beDF8f0B5984648f2fE64a7A120Dab800",
+    "4": "0xa70d0d0BE1F02cF646D5CDB6716a509A937f3EE5"
+  },
+  "cssvToken": "0xDAaeb8f1fbE25433aAcd296888B77165e6F5e3bA",
+  "deployBlockNumber": 11229372,
+  "modules": {
+    "SSVOperators": "0x1fBc1D8Fb9c6BD04a46370F984deAe5C709B1D5F",
+    "SSVClusters": "0x254469ffDf985DcDFaB468fC3B027cFf8c025AF4",
+    "SSVDAO": "0x2BDfC067C860DeB5Db4367F063c579dD868A2708",
+    "SSVViews": "0x6bfaEaCF997BaFc696070F15ED82a5750d8247C8",
+    "SSVOperatorsWhitelist": "0x7291563A48cb408e551a3529f8bd7C1413E8122D",
+    "SSVStaking": "0x6dC10514716C96F34550e04cf059f73bBF229f4E",
+    "SSVValidators": "0xfCD7243D8fBb441497fEd67e19B7681C27BB20aD"
+  },
+  "deployments": {
+    "ssvNetworkStakingUpgradeImplementation": "0x1C88912Ea7705D8C8747DF7C50617cD29AF62fe6",
+    "ssvNetworkViewsImplementation": "0xbC126c20D3B47C334Ed70b910e79a4F2428fecCc",
+    "cssvToken": "0xDAaeb8f1fbE25433aAcd296888B77165e6F5e3bA",
+    "modules": {
+      "SSVOperators": "0x1fBc1D8Fb9c6BD04a46370F984deAe5C709B1D5F",
+      "SSVClusters": "0x254469ffDf985DcDFaB468fC3B027cFf8c025AF4",
+      "SSVDAO": "0x2BDfC067C860DeB5Db4367F063c579dD868A2708",
+      "SSVViews": "0x6bfaEaCF997BaFc696070F15ED82a5750d8247C8",
+      "SSVOperatorsWhitelist": "0x7291563A48cb408e551a3529f8bd7C1413E8122D",
+      "SSVStaking": "0x6dC10514716C96F34550e04cf059f73bBF229f4E",
+      "SSVValidators": "0xfCD7243D8fBb441497fEd67e19B7681C27BB20aD"
+    },
+    "targetNetwork": "sepolia",
+    "deployBlockNumber": 11229372,
+    "chainId": "11155111",
+    "updatedAt": "2026-07-08T12:30:50.352Z"
+  }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -14,6 +14,10 @@ const localForkChainId = 31337;
 const mainnetRpcUrl =
   envValue("MAINNET_RPC_URL") ??
   configVariable("MAINNET_RPC_URL");
+const sepoliaRpcUrl =
+  envValue("SEPOLIA_RPC_URL") ??
+  envValue("SEPOLIA_RPC") ??
+  configVariable("SEPOLIA_RPC_URL");
 
 export default defineConfig({
   plugins: [hardhatToolboxMochaEthersPlugin],
@@ -85,6 +89,13 @@ export default defineConfig({
       url: mainnetRpcUrl,
       accounts: [configVariable("MAINNET_PRIVATE_KEY")],
       ssvToken: process.env.MAINNET_SSVTOKEN_ADDRESS
+    },
+    sepolia: {
+      type: "http",
+      chainType: "l1",
+      url: sepoliaRpcUrl,
+      accounts: [configVariable("SEPOLIA_PRIVATE_KEY")],
+      ssvToken: process.env.SEPOLIA_SSVTOKEN_ADDRESS
     }
   },
   verify: {

--- a/scripts/common/config.ts
+++ b/scripts/common/config.ts
@@ -123,6 +123,7 @@ export function resolveNetworkFromEnv(env: string | undefined): string | undefin
   if (env === "mainnet") return "mainnet";
   if (env === "local") return "local";
   if (env.startsWith("hoodi")) return "hoodi";
+  if (env.startsWith("sepolia")) return "sepolia";
   return undefined;
 }
 

--- a/scripts/common/impersonation.ts
+++ b/scripts/common/impersonation.ts
@@ -82,5 +82,6 @@ export function resolveRpcUrl(targetNetwork: string): string | undefined {
   if (isLocalNetwork) return "http://127.0.0.1:8545";
   if (targetNetwork === "hoodi") return process.env.HOODI_RPC_URL;
   if (targetNetwork === "mainnet") return process.env.MAINNET_RPC_URL;
+  if (targetNetwork === "sepolia") return process.env.SEPOLIA_RPC_URL ?? process.env.SEPOLIA_RPC;
   return undefined;
 }


### PR DESCRIPTION
  ## Add Sepolia environment support for v1.2.0 → v2.0.0 upgrade                                                                                                                     
                                                                                                                                                                                     
  Wires Sepolia into the deployment tooling (previously only mainnet/hoodi/local were supported) and adds the Sepolia upgrade config.                                                
                                                                                                                                                                                     
  ### Changes                                                                                                                                                                        
  - **hardhat.config.ts** — add `sepolia` network (RPC from `SEPOLIA_RPC_URL`/`SEPOLIA_RPC`, signer from `SEPOLIA_PRIVATE_KEY`, optional `SEPOLIA_SSVTOKEN_ADDRESS`)                 
  - **scripts/common/config.ts** — `resolveNetworkFromEnv` maps `sepolia*` env → `sepolia` network                                                                                   
  - **scripts/common/impersonation.ts** — `resolveRpcUrl` resolves the Sepolia RPC                                                                                                   
  - **.env.example** — document `SEPOLIA_RPC_URL` / `SEPOLIA_PRIVATE_KEY` / `SEPOLIA_SSVTOKEN_ADDRESS`                                                                               
  - **deployments/sepolia/config.json** — new upgrade config (`v1.2.0` → `v2.0.0`, `skipInitializer: false`), hoodi-stage protocol params + oracle set, owner `0xC564…67b40`         
        